### PR TITLE
heimdall/gateway/filter/helper/DBImpl: buildPage's flags fixed.

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/DBImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/DBImpl.java
@@ -288,11 +288,11 @@ public class DBImpl implements DB {
           pageResponse.numberOfElements = limit;
           pageResponse.totalElements = totalElements;
           pageResponse.hasPreviousPage = page > 0;
-          pageResponse.hasNextPage = page < pageResponse.totalPages;
+          pageResponse.hasNextPage = page < (pageResponse.totalPages - 1);
           pageResponse.hasContent = Objeto.notBlank(list);
           pageResponse.first = page == 0;
-          pageResponse.last = page == pageResponse.totalPages;
-          pageResponse.nextPage = page == pageResponse.totalPages ? pageResponse.totalPages : page + 1;
+          pageResponse.last = page == (pageResponse.totalPages - 1);
+          pageResponse.nextPage = page == (pageResponse.totalPages - 1) ? page : page + 1;
           pageResponse.previousPage = page == 0 ? 0 : page - 1;
           pageResponse.content = list;
 


### PR DESCRIPTION
Hi,

This commits fixe the "buildPage" of DBImpl. These changes correct the paging control flags, for example, the hasNextPage flag. Remember that paging starts with the zero value.

What do you think @MAAARKIN and @filipegermano ?