### PR TITLE
Fixed double wild card validation

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OperationService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OperationService.java
@@ -254,12 +254,12 @@ public class OperationService {
       * @return true when the path has more than one double wild card or one not at the end, false otherwise
       */
      private static boolean validateDoubleWildCardOperationPath(Operation operation) {
-          List<String> path = Arrays.asList(operation.getPath().split("/"));
-          
-          if (path.stream().filter(o -> o.equals("**")).count() > 1)
-               return true;
-          else 
-               return !operation.getPath().endsWith("**");
-     }
+         List<String> path = Arrays.asList(operation.getPath().split("/"));
+                   
+         if (path.contains("**"))
+        	 return !operation.getPath().endsWith("**") || !(path.stream().filter(o -> o.equals("**")).count() == 1);              
+         else 
+       	 	 return false;
+    }
 
 }


### PR DESCRIPTION
The double wild card validation method is not allowing the creation of paths that have no wild cards.
That is not how it is supposed to work.

Valid paths are:
 * paths with no wild card
 * paths with double wild card at the end

This change fixed the issue #38 