### PR TITLE
Fix Req/Res Trace to save on MongoDB

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/appender/MongoDBAppender.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/appender/MongoDBAppender.java
@@ -30,6 +30,7 @@ import org.bson.Document;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -53,7 +54,6 @@ import lombok.extern.slf4j.Slf4j;
 public class MongoDBAppender extends AppenderBase<LoggingEvent> {
 
      private MongoClient mongoClient;
-
      private MongoCollection<Document> collection;
      
      @Setter @Getter
@@ -64,7 +64,8 @@ public class MongoDBAppender extends AppenderBase<LoggingEvent> {
      private String dataBase;
      @Setter @Getter
      private String collectionName;
-     
+     @Setter @Getter
+     private String uri;
      
      public MongoDBAppender(String url, Long port, String dataBase, String collectionName) {
           this.url = url;
@@ -72,13 +73,24 @@ public class MongoDBAppender extends AppenderBase<LoggingEvent> {
           this.dataBase = dataBase;
           this.collectionName = collectionName;
      }
+     
+     public MongoDBAppender(String uri, String dataBase, String collectionName) {
+    	 this.uri = uri;
+    	 this.dataBase = dataBase;
+    	 this.collectionName = collectionName;
+     }
 
      @Override
      public void start() {
           log.info("Initializing Mongodb Appender");
-          MongoClientOptions options = new MongoClientOptions.Builder().socketKeepAlive(true).build();
-          ServerAddress address = new ServerAddress(this.url, this.port.intValue());
-          this.mongoClient = new MongoClient(address, options);
+          if (this.uri != null) {
+        	  this.mongoClient = new MongoClient(new MongoClientURI(this.uri));
+          } else {
+        	  MongoClientOptions options = new MongoClientOptions.Builder().socketKeepAlive(true).build();
+        	  ServerAddress address = new ServerAddress(this.url, this.port.intValue());
+        	  this.mongoClient = new MongoClient(address, options);  
+          }
+          
           MongoDatabase database = this.mongoClient.getDatabase(this.dataBase);
           this.collection = database.getCollection(this.collectionName);
           log.info("Starting connection with url: {} - port: {}", this.url, this.port);

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
@@ -1,5 +1,4 @@
-
-package br.com.conductor.heimdall.core.appender;
+package br.com.conductor.heimdall.gateway.appender;
 
 /*-
  * =========================LICENSE_START==================================
@@ -35,7 +34,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
-import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,7 +50,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @NoArgsConstructor
-public class MongoDBAppender extends AppenderBase<LoggingEvent> {
+public class MongoDBAppender extends AppenderBase<ILoggingEvent> {
 
      private MongoClient mongoClient;
      private MongoCollection<Document> collection;
@@ -106,10 +105,10 @@ public class MongoDBAppender extends AppenderBase<LoggingEvent> {
      }
 
      @Override
-     protected void append(LoggingEvent e) {
+     protected void append(ILoggingEvent e) {
           Map<String, Object> objLog = new HashMap<>();
           objLog.put("ts", new Date(e.getTimeStamp()));
-          objLog.put("msg", e.getFormattedMessage());
+          objLog.put("trace", BasicDBObject.parse(e.getFormattedMessage()));
           objLog.put("level", e.getLevel().toString());
           objLog.put("logger", e.getLoggerName());
           objLog.put("thread", e.getThreadName());
@@ -123,7 +122,6 @@ public class MongoDBAppender extends AppenderBase<LoggingEvent> {
           if (mdc != null && !mdc.isEmpty()) {
                objLog.put("mdc", new BasicDBObject(mdc));
           }
-//          BasicDBObject content = new BasicDBObject(objLog);
           collection.insertOne(new Document(objLog));
      }
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
@@ -77,9 +77,13 @@ public class LogConfiguration {
           if (property.getMongo().getEnabled()) {
                LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
                Logger logger = (Logger) LoggerFactory.getLogger(Trace.class);
-
                @SuppressWarnings("rawtypes")
-               Appender appender = new MongoDBAppender(property.getMongo().getServerName(), property.getMongo().getPort(), property.getMongo().getDataBase(), property.getMongo().getCollection());
+               Appender appender;
+               if (property.getMongo().getUrl() != null) {
+            	   appender = new MongoDBAppender(property.getMongo().getUrl(), property.getMongo().getDataBase(), property.getMongo().getCollection());
+               } else {
+            	   appender = new MongoDBAppender(property.getMongo().getServerName(), property.getMongo().getPort(), property.getMongo().getDataBase(), property.getMongo().getCollection());            	   
+               }
                appender.setContext(lc);
                appender.start();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
@@ -1,5 +1,5 @@
-
 package br.com.conductor.heimdall.gateway.configuration;
+
 
 /*-
  * =========================LICENSE_START==================================
@@ -21,16 +21,18 @@ package br.com.conductor.heimdall.gateway.configuration;
  * ==========================LICENSE_END===================================
  */
 
+import javax.annotation.PostConstruct;
+
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import br.com.conductor.heimdall.core.appender.MongoDBAppender;
 import br.com.conductor.heimdall.core.environment.Property;
-import br.com.conductor.heimdall.gateway.trace.Trace;
+import br.com.conductor.heimdall.gateway.appender.MongoDBAppender;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import net.logstash.logback.appender.LogstashTcpSocketAppender;
 import net.logstash.logback.encoder.LogstashEncoder;
@@ -47,12 +49,31 @@ public class LogConfiguration {
 
      @Autowired
      private Property property;
+     
+     @PostConstruct
+     public void onStartUp() {
+    	 if (property.getMongo().getEnabled()) {
+    		 
+             LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+             Logger logger = (Logger) LoggerFactory.getLogger("mongo");
+             logger.setAdditive(false);
+             Appender<ILoggingEvent> appender;
+             if (property.getMongo().getUrl() != null) {
+          	   appender = new MongoDBAppender(property.getMongo().getUrl(), property.getMongo().getDataBase(), property.getMongo().getCollection());
+             } else {
+          	   appender = new MongoDBAppender(property.getMongo().getServerName(), property.getMongo().getPort(), property.getMongo().getDataBase(), property.getMongo().getCollection());            	   
+             }
+             appender.setContext(lc);
+             appender.start();
+
+             logger.addAppender(appender);
+        }
+     }
 
      /**
       * Returns the proper logging strategy.
       * @return		
       */
-     @SuppressWarnings("unchecked")
      @Bean
      public Logger loggerTrace() {
 
@@ -72,22 +93,6 @@ public class LogConfiguration {
 
                logger.addAppender(appender);
 
-          }
-
-          if (property.getMongo().getEnabled()) {
-               LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-               Logger logger = (Logger) LoggerFactory.getLogger(Trace.class);
-               @SuppressWarnings("rawtypes")
-               Appender appender;
-               if (property.getMongo().getUrl() != null) {
-            	   appender = new MongoDBAppender(property.getMongo().getUrl(), property.getMongo().getDataBase(), property.getMongo().getCollection());
-               } else {
-            	   appender = new MongoDBAppender(property.getMongo().getServerName(), property.getMongo().getPort(), property.getMongo().getDataBase(), property.getMongo().getCollection());            	   
-               }
-               appender.setContext(lc);
-               appender.start();
-
-               logger.addAppender(appender);
           }
 
           return null;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
@@ -31,6 +31,9 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -56,6 +59,8 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 @Slf4j
 public class Trace {
+	
+	 private static final Logger logMongo = LoggerFactory.getLogger("mongo");
 
      private String method;
 
@@ -107,6 +112,10 @@ public class Trace {
      
      @JsonIgnore
      private boolean printAllTrace;
+     
+     public Trace() {
+    	 
+     }
 
      /**
       * Creates a Trace.
@@ -200,6 +209,7 @@ public class Trace {
                     }
                     
                     log.info(append("call", this), " [HEIMDALL-TRACE] - " + url);
+                    logMongo.info(new ObjectMapper().writeValueAsString(this));
                }
 
           } catch (Exception e) {


### PR DESCRIPTION
Currently its possible add the request **trace** to mongodb if the properties is enabled. But if the mongo properties in the application.yml was configured with mongo URI connection the MongoAppender.java was not connecting because was not configured with MongoClientURI.

This PR make more flexible the application to sync the mongodb middlewares and MongoAppender (SL4J) to use same database but different collections

@thiagonego now we put the trace json in mongodb and now its possible to planning an Api to consulting the traces in database and provide an view to see all traces in front-end
