### PR TITLE
Fixed bug when creating an operation using the frontend.

### DIFF
--- a/heimdall-frontend/src/containers/Operations.js
+++ b/heimdall-frontend/src/containers/Operations.js
@@ -3,7 +3,6 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { operationService } from '../services'
-import { toggleModal } from '../actions/operations'
 
 import { List, Avatar, Button, Row, Col, Tooltip, Modal, notification } from 'antd';
 import Loading from '../components/ui/Loading'
@@ -15,7 +14,7 @@ class Operations extends Component {
 
     constructor(props) {
         super(props)
-        this.state = { operations: null, operationSelected: 0 }
+        this.state = { operations: null, operationSelected: 0, visibleModal: false }
     }
 
     componentDidMount() {
@@ -30,15 +29,15 @@ class Operations extends Component {
     }
 
     showOperationModal = (operationId) => (e) => {
+        let newOperationId = this.state.operationSelected;
         if (operationId) {
-            this.setState({ ...this.state, operationSelected: operationId });
+            newOperationId = operationId
         }
-        this.props.toggleModal(true)
+        this.setState({ ...this.state, operationSelected: newOperationId, visibleModal: true });
     }
 
     handleCancel = (e) => {
-        this.props.toggleModal(false)
-        this.setState({ ...this.state, operationSelected: 0 });
+        this.setState({ ...this.state, operationSelected: 0, visibleModal: false });
     }
 
     reloadOperations = () => {
@@ -80,8 +79,7 @@ class Operations extends Component {
 
     handleSave = (e) => {
         this.operationForm.onSubmitForm()
-        this.setState({ ...this.state, operationSelected: 0, operations: null });
-        this.props.toggleModal(false)
+        this.setState({ ...this.state, operationSelected: 0, operations: null, visibleModal: false });
     }
 
     submitPayload = (payload) => {
@@ -104,11 +102,12 @@ class Operations extends Component {
 
         const modalOperation =
             <Modal title="Add Operation"
+            
                 footer={[
                     <Button key="back" onClick={this.handleCancel}>Cancel</Button>,
                     <Button key="submit" type="primary" loading={loading} onClick={this.handleSave}>Save</Button>
                 ]}
-                visible={this.props.visibleModal}
+                visible={this.state.visibleModal}
                 onCancel={this.handleCancel}
                 destroyOnClose >
                 <OperationForm onRef={ref => (this.operationForm = ref)} onSubmit={this.submitPayload} operationId={this.state.operationSelected} idApi={this.props.idApi} idResource={this.props.idResource} />
@@ -193,16 +192,9 @@ Operations.propType = {
 
 const mapStateToProps = state => {
     return {
-        visibleModal: state.operations.visibleModal,
         loading: state.operations.loading,
         reload: state.operations.reload
     }
 }
 
-const mapDispatchToProps = dispatch => {
-    return {
-        toggleModal: bindActionCreators(toggleModal, dispatch)
-    }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Operations)
+export default connect(mapStateToProps)(Operations)


### PR DESCRIPTION
**Describe the bug**
When all the resources were opened in the front end and clicked to add some operation, this operation was always saved in the last resource because they were showing all the forms of the operations due to the visibility state of the modal was shared in redux.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to api
2. Click on tab Resources
3. Open all tab-accordion Resources
4. Click on AddOperation of the first Resource and save Operation
5. See error

**Expected behavior**
The operations must be registered in their respective Resource

**Desktop:**
 - OS: Windows 10
 - Chrome
 - Version  66.0.3359.181 (64 bits)

**To fix I do**
Removed modal visibility state from redux. Now available only inside Operations Component.
