### PR TITLE
Fix bug duplicate interceptor

### DIFF
--- a/heimdall-frontend/src/components/interceptors/DnDInterceptorType.js
+++ b/heimdall-frontend/src/components/interceptors/DnDInterceptorType.js
@@ -77,7 +77,7 @@ class DnDInterceptorType extends Component {
                     </Badge>
                     <span>{type}</span>
 
-                    <Modal title="Add Resource"
+                    <Modal title="Add Interceptor"
                         footer={[
                             <Button key="back" onClick={this.handleCancel}>Cancel</Button>,
                             <Button key="submit" type="primary" onClick={this.handleSave}>

--- a/heimdall-frontend/src/components/interceptors/InterceptorForm.js
+++ b/heimdall-frontend/src/components/interceptors/InterceptorForm.js
@@ -89,6 +89,7 @@ class InterceptorForm extends Component {
             <Row>
                 <Form>
                     {interceptor && getFieldDecorator('id', { initialValue: interceptor.id })(<Input type='hidden' />)}
+                    {interceptor && interceptor.uuid && getFieldDecorator('uuid', { initialValue: interceptor.uuid })(<Input type='hidden' />)}
                     {getFieldDecorator('referenceId', { initialValue: interceptor ? interceptor.referenceId : referenceId })(<Input type='hidden' />)}
                     {environmentId && getFieldDecorator('environment', { initialValue: environmentId })(<Input type='hidden' />)}
 

--- a/heimdall-frontend/src/containers/Interceptors.js
+++ b/heimdall-frontend/src/containers/Interceptors.js
@@ -115,8 +115,8 @@ class Interceptors extends Component {
         } else {
             formObject.status = 'SAVE'
             let candidates = this.state.candidatesToSave
-            if (this.state.candidatesToSave.some(updatable => updatable === formObject)) {
-                candidates = this.state.candidatesToSave.filter(item => item !== formObject)
+            if (this.state.candidatesToSave.some(updatable => updatable.uuid === formObject.uuid)) {
+                candidates = this.state.candidatesToSave.filter(item => item.uuid !== formObject.uuid)
             }
 
             formObject.uuid = UUID.generate()


### PR DESCRIPTION
**Describe the bug**
When an interceptor was added and saved locally on the frontend and tried to edit then the interceptor duplicate only in view.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to API's
2. Click on tab Interceptors
3. Select some operation
4. Drag and drop some interceptor type (circles above the drag area) and save it only by clicking on the button "Save" of the modal
5. Drag and drop the interceptor create again to edit
6. Update some attribute and save
7. See error

**Expected behavior**
When editing a local interceptor, the same information must be updated without duplicate the interceptor.

**Desktop (please complete the following information):**
 - OS: Window 10
 - Browser: Chrome
 - Version: 67.0.3396.62 (64 bits)

**To fix I do**
When an interceptor is created, a UUID is added. Before edit a interceptor is checked if the UUID already exists, if it exists, the old one is removed and the new one is added the list of candidates to be saved with the new values.
