### PR TITLE
Middleware handling

### DIFF
--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -78,6 +78,8 @@ heimdall:
             #userDn: your@mail.user
             #password: password
             #userSearchFilter: sAMAccountName={0}    
+    middlewares:
+        rollbackLevels: 0
 
 spring:
     pid:

--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -80,6 +80,7 @@ heimdall:
             #userSearchFilter: sAMAccountName={0}    
     middlewares:
         allowInactive: 0
+        deleteDeprecated: true
 
 spring:
     pid:

--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -79,7 +79,7 @@ heimdall:
             #password: password
             #userSearchFilter: sAMAccountName={0}    
     middlewares:
-        rollbackLevels: 0
+        allowInactive: 0
 
 spring:
     pid:

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/enums/Status.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/enums/Status.java
@@ -29,5 +29,5 @@ package br.com.conductor.heimdall.core.enums;
  */
 public enum Status {
 
-     ACTIVE, INACTIVE, REVOKED;
+     ACTIVE, INACTIVE, REVOKED, DEPRECATED;
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
@@ -165,7 +165,7 @@ public class Property {
      
      @Data
      public class Middlewares {
-    	 private Integer rollbackLevels;
+    	 private Integer allowInactive;
      }
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
@@ -160,5 +160,12 @@ public class Property {
           private boolean printAllTrace = false;
           private List<String> sanitizes = new ArrayList<>();
      }
+     
+     private Middlewares middlewares = new Middlewares();
+     
+     @Data
+     public class Middlewares {
+    	 private Integer rollbackLevels;
+     }
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
@@ -166,6 +166,7 @@ public class Property {
      @Data
      public class Middlewares {
     	 private Integer allowInactive;
+    	 private Boolean deleteDeprecated;
      }
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
@@ -65,7 +65,8 @@ import br.com.twsoftware.alfred.object.Objeto;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * This class provides methods to create, read, update and delete the {@link Middleware} resource.
+ * This class provides methods to create, read, update and delete the
+ * {@link Middleware} resource.
  * 
  * @author Filipe Germano
  *
@@ -74,216 +75,224 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MiddlewareService {
 
-     @Autowired
-     private MiddlewareRepository middlewareRepository;
+	@Autowired
+	private MiddlewareRepository middlewareRepository;
 
-     @Autowired
-     private ApiRepository apiRepository;
+	@Autowired
+	private ApiRepository apiRepository;
 
-     @Autowired
-     private InterceptorRepository interceptorRepository;
-     
-     @Autowired
-     private Property property;
+	@Autowired
+	private InterceptorRepository interceptorRepository;
 
-     @Value("${zuul.filter.root}")
-     private String root; 
-     
-     @Autowired
-     private AMQPMiddlewareService amqpMiddlewareService;
+	@Autowired
+	private Property property;
 
-     /**
-      * Finds a {@link Middleware} by its Id and {@link Api} Id.
-      * 
-      * @param 	apiId 					The {@link Api} Id
-      * @param 	middlewareId 			The {@link Middleware} Id
-      * @return  						The {@link Middleware} associated with the {@link Api}
-      * @throws NotFoundException 		Resource not found
-      */
-     @Transactional(readOnly = true)
-     public Middleware find(Long apiId, Long middlewareId) {
-          
-          Middleware middleware = middlewareRepository.findByApiIdAndId(apiId, middlewareId);      
-          HeimdallException.checkThrow(isBlank(middleware), GLOBAL_RESOURCE_NOT_FOUND);
-          
-          return middleware;
-     }
-     
-     /**
-      * Generates a paged list of the {@link Middleware} associated with a {@link Api}.
-      * 
-      * @param 	apiId 					The ID of the {@link Api} 
-      * @param 	middlewareDTO 			The {@link MiddlewareDTO}
-      * @param	pageableDTO 			The {@link PageableDTO}
-      * @return  						A paged {@link Middleware} list as a {@link MiddlewarePage} object
-      * @throws NotFoundException 		Resource not found 
-      */
-     @Transactional(readOnly = true)
-     public MiddlewarePage list(Long apiId, MiddlewareDTO middlewareDTO, PageableDTO pageableDTO) {
+	@Value("${zuul.filter.root}")
+	private String root;
 
-          Api api = apiRepository.findOne(apiId);
-          HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
-          
-          Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
-          middleware.setApi(api);
-          
-          Example<Middleware> example = Example.of(middleware, ExampleMatcher.matching().withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
-          
-          Pageable pageable = Pageable.setPageable(pageableDTO.getOffset(), pageableDTO.getLimit());
-          Page<Middleware> page = middlewareRepository.findAll(example, pageable);
-          
-          MiddlewarePage middlewarePage = new MiddlewarePage(PageDTO.build(page));
-          
-          return middlewarePage;
-     }
+	@Autowired
+	private AMQPMiddlewareService amqpMiddlewareService;
 
-     /**
-      * Generates a list of the {@link Middleware} associated with a {@link Api}.
-      * 
-      * @param 	apiId 						The ID of the API 
-      * @param 	middlewareDTO 				The middleware DTO
-      * @return 						 	The list of {@link Middleware}
-      * @throws NotFoundException 			Resource not found
-      */
-     @Transactional(readOnly = true)
-     public List<Middleware> list(Long apiId, MiddlewareDTO middlewareDTO) {
-          
-          Api api = apiRepository.findOne(apiId);
-          HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
-          
-          Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
-          Api apiFind = new Api();
-          apiFind.setId(apiId);
-          middleware.setApi(apiFind);
-          
-          Example<Middleware> example = Example.of(middleware, ExampleMatcher.matching().withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
-          
-          List<Middleware> middlewares = middlewareRepository.findAll(example);
-          
-          return middlewares;
-     }
-     
-     /**
-      * Save a new {@link Middleware} for a {@link Api}.
-      * 
-      * @param 	apiId 					The {@link Api} Id
-      * @param 	middlewareDTO 			The {@link MiddlewareDTO}
-      * @param 	file 					The packaged {@link Middleware} file
-      * @return 						The new {@link Middleware} created
-      * @throws NotFoundException 		Resource not found
-      * @throws BadRequestException		Only one middleware per version and api
-      * @throws BadRequestException		File type differs from .jar not supported
-      * @throws BadRequestException		Invalid middleware file
-      */
-     @Transactional
-     public Middleware save(Long apiId, MiddlewareDTO middlewareDTO, MultipartFile file) {
-          
-    	  List<Middleware> middlewares = middlewareRepository.findByApiId(apiId);
-          Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
-        		  .collect(Collectors.groupingBy(m -> m.getStatus()));
-          
-          Integer allowInactive = property.getMiddlewares().getAllowInactive();
-    	  
-          if (Objeto.notBlank(allowInactive) && allowInactive != 0) {
-        	    
-        	  List<Middleware> active = middlewareMap.get(Status.ACTIVE);
-        	  List<Middleware> inactive = middlewareMap.get(Status.INACTIVE);
-        	  
-        	  active.forEach(m -> m.setStatus(Status.INACTIVE));
-        	  inactive.addAll(active);
-        	  inactive.sort((m1, m2) -> m2.getCreationDate().compareTo(m1.getCreationDate()));
-        	  
-    		  inactive.stream().skip(allowInactive).forEach(m -> {
-    			  m.setStatus(Status.DEPRECATED);
-    			  m.setFile(null);
-    		  });
-        	  
-          } else {
-        	  middlewareMap.get(Status.ACTIVE).forEach(m -> m.setStatus(Status.INACTIVE));
-          }
-          
-          middlewareRepository.save(middlewares);
-          
-          Api api = apiRepository.findOne(apiId);
-          HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
-                    
-          Middleware resData = middlewareRepository.findByApiIdAndVersion(apiId, middlewareDTO.getVersion());
-          HeimdallException.checkThrow(notBlank(resData) && (resData.getApi().getId() == api.getId()), ONLY_ONE_MIDDLEWARE_PER_VERSION_AND_API);
-          
-          String type = FilenameUtils.getExtension(file.getOriginalFilename());
-          HeimdallException.checkThrow(!("jar".equalsIgnoreCase(type)), MIDDLEWARE_UNSUPPORTED_TYPE);
-          
-          Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
-          middleware.setApi(api);
-          middleware.setPath(root + "/api/" + apiId + "/middleware");
-          middleware.setType(type);
-          try {
-               
-               middleware.setFile(file.getBytes());
-          } catch (Exception e) {
-               
-               log.error(e.getMessage(), e);
-               HeimdallException.checkThrow(isBlank(api), MIDDLEWARE_INVALID_FILE);
-          }
-          
-          List<Interceptor> interceptors = interceptorRepository.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, middleware.getApi().getId());
-          middleware.setInterceptors(interceptors);
-          middleware = middlewareRepository.save(middleware);          
-          
-          amqpMiddlewareService.dispatchCreateMiddlewares(middleware.getId());
-          
-          return middleware;
-     }
+	/**
+	 * Finds a {@link Middleware} by its Id and {@link Api} Id.
+	 * 
+	 * @param apiId              The {@link Api} Id
+	 * @param middlewareId       The {@link Middleware} Id
+	 * @return                   The {@link Middleware} associated with the {@link Api}
+	 * @throws NotFoundException Resource not found
+	 */
+	@Transactional(readOnly = true)
+	public Middleware find(Long apiId, Long middlewareId) {
 
-     /**
-      * Updates a middleware by Middleware ID and API ID.
-      * 
-      * @param 	apiId 					The ID of the API
-      * @param 	middlewareId 			The middleware ID
-      * @param	middlewareDTO 			The middleware DTO
-      * @return 						The middleware that was updated
-      * @throws NotFoundException		Resource not found
-      * @throws BadRequestException		Only one middleware per version and api
-      */
-     @Transactional
-     public Middleware update(Long apiId, Long middlewareId, MiddlewareDTO middlewareDTO) {
+		Middleware middleware = middlewareRepository.findByApiIdAndId(apiId, middlewareId);
+		HeimdallException.checkThrow(isBlank(middleware), GLOBAL_RESOURCE_NOT_FOUND);
 
-          Middleware middleware = middlewareRepository.findByApiIdAndId(apiId, middlewareId);
-          HeimdallException.checkThrow(isBlank(middleware), GLOBAL_RESOURCE_NOT_FOUND);
-          
-          Middleware resData = middlewareRepository.findByApiIdAndVersion(apiId, middlewareDTO.getVersion());
-          HeimdallException.checkThrow(notBlank(resData) && (resData.getApi().getId() == middleware.getApi().getId()) && (resData.getId() != middleware.getId()), ONLY_ONE_MIDDLEWARE_PER_VERSION_AND_API);
-          
-          middleware = GenericConverter.mapper(middlewareDTO, middleware);
-          
-          if (middleware.getStatus().equals(Status.DEPRECATED))
-        	  middleware.setFile(null);
-          
-          middleware = middlewareRepository.save(middleware);
-          
-          amqpMiddlewareService.dispatchCreateMiddlewares(middlewareId);
-          
-          return middleware;
-     }
-     
-     /**
-      * Deletes a middleware by API ID and middleware ID
-      * 
-      * @param 	apiId					The ID of the API 
-      * @param 	middlewareId			The middleware ID
-      * @throws NotFoundException		Resource not found
-      * @throws BadRequestException		Middleware still contains interceptors associated
-      */
-     @Transactional
-     public void delete(Long apiId, Long middlewareId) {
+		return middleware;
+	}
 
-          Middleware middleware = middlewareRepository.findByApiIdAndId(apiId, middlewareId);
-          HeimdallException.checkThrow(isBlank(middleware), GLOBAL_RESOURCE_NOT_FOUND);
-          HeimdallException.checkThrow((Objeto.notBlank(middleware.getInterceptors()) && middleware.getInterceptors().size() > 0), ExceptionMessage.MIDDLEWARE_CONTAINS_INTERCEOPTORS);
-               
-          amqpMiddlewareService.dispatchRemoveMiddlewares(middleware.getPath());
-          middlewareRepository.delete(middleware.getId());
-          
-     }
+	/**
+	 * Generates a paged list of the {@link Middleware} associated with a
+	 * {@link Api}.
+	 * 
+	 * @param apiId              The ID of the {@link Api}
+	 * @param middlewareDTO      The {@link MiddlewareDTO}
+	 * @param pageableDTO        The {@link PageableDTO}
+	 * @return                   A paged {@link Middleware} list as a {@link MiddlewarePage} object
+	 * @throws NotFoundException Resource not found
+	 */
+	@Transactional(readOnly = true)
+	public MiddlewarePage list(Long apiId, MiddlewareDTO middlewareDTO, PageableDTO pageableDTO) {
+
+		Api api = apiRepository.findOne(apiId);
+		HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
+
+		Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
+		middleware.setApi(api);
+
+		Example<Middleware> example = Example.of(middleware,
+				ExampleMatcher.matching().withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
+
+		Pageable pageable = Pageable.setPageable(pageableDTO.getOffset(), pageableDTO.getLimit());
+		Page<Middleware> page = middlewareRepository.findAll(example, pageable);
+
+		MiddlewarePage middlewarePage = new MiddlewarePage(PageDTO.build(page));
+
+		return middlewarePage;
+	}
+
+	/**
+	 * Generates a list of the {@link Middleware} associated with a {@link Api}.
+	 * 
+	 * @param apiId              The ID of the API
+	 * @param middlewareDTO      The middleware DTO
+	 * @return                   The list of {@link Middleware}
+	 * @throws NotFoundException Resource not found
+	 */
+	@Transactional(readOnly = true)
+	public List<Middleware> list(Long apiId, MiddlewareDTO middlewareDTO) {
+
+		Api api = apiRepository.findOne(apiId);
+		HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
+
+		Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
+		Api apiFind = new Api();
+		apiFind.setId(apiId);
+		middleware.setApi(apiFind);
+
+		Example<Middleware> example = Example.of(middleware,
+				ExampleMatcher.matching().withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
+
+		List<Middleware> middlewares = middlewareRepository.findAll(example);
+
+		return middlewares;
+	}
+
+	/**
+	 * Save a new {@link Middleware} for a {@link Api}.
+	 * 
+	 * @param apiId                The {@link Api} Id
+	 * @param middlewareDTO        The {@link MiddlewareDTO}
+	 * @param file                 The packaged {@link Middleware} file
+	 * @return                     The new {@link Middleware} created
+	 * @throws NotFoundException   Resource not found
+	 * @throws BadRequestException Only one middleware per version and api
+	 * @throws BadRequestException File type differs from .jar not supported
+	 * @throws BadRequestException Invalid middleware file
+	 */
+	@Transactional
+	public Middleware save(Long apiId, MiddlewareDTO middlewareDTO, MultipartFile file) {
+
+		List<Middleware> middlewares = middlewareRepository.findByApiId(apiId);
+		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+				.collect(Collectors.groupingBy(m -> m.getStatus()));
+
+		Integer allowInactive = property.getMiddlewares().getAllowInactive();
+
+		if (Objeto.notBlank(allowInactive) && allowInactive != 0) {
+
+			List<Middleware> active = middlewareMap.get(Status.ACTIVE);
+			List<Middleware> inactive = middlewareMap.get(Status.INACTIVE);
+
+			active.forEach(m -> m.setStatus(Status.INACTIVE));
+			inactive.addAll(active);
+			inactive.sort((m1, m2) -> m2.getCreationDate().compareTo(m1.getCreationDate()));
+
+			inactive.stream().skip(allowInactive).forEach(m -> {
+				m.setStatus(Status.DEPRECATED);
+				m.setFile(null);
+			});
+
+		} else {
+			middlewareMap.get(Status.ACTIVE).forEach(m -> m.setStatus(Status.INACTIVE));
+		}
+
+		middlewareRepository.save(middlewares);
+
+		Api api = apiRepository.findOne(apiId);
+		HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
+
+		Middleware resData = middlewareRepository.findByApiIdAndVersion(apiId, middlewareDTO.getVersion());
+		HeimdallException.checkThrow(notBlank(resData) && (resData.getApi().getId() == api.getId()),
+				ONLY_ONE_MIDDLEWARE_PER_VERSION_AND_API);
+
+		String type = FilenameUtils.getExtension(file.getOriginalFilename());
+		HeimdallException.checkThrow(!("jar".equalsIgnoreCase(type)), MIDDLEWARE_UNSUPPORTED_TYPE);
+
+		Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
+		middleware.setApi(api);
+		middleware.setPath(root + "/api/" + apiId + "/middleware");
+		middleware.setType(type);
+		try {
+
+			middleware.setFile(file.getBytes());
+		} catch (Exception e) {
+
+			log.error(e.getMessage(), e);
+			HeimdallException.checkThrow(isBlank(api), MIDDLEWARE_INVALID_FILE);
+		}
+
+		List<Interceptor> interceptors = interceptorRepository
+				.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, middleware.getApi().getId());
+		middleware.setInterceptors(interceptors);
+		middleware = middlewareRepository.save(middleware);
+
+		amqpMiddlewareService.dispatchCreateMiddlewares(middleware.getId());
+
+		return middleware;
+	}
+
+	/**
+	 * Updates a middleware by Middleware ID and API ID.
+	 * 
+	 * @param apiId                The ID of the API
+	 * @param middlewareId         The middleware ID
+	 * @param middlewareDTO        The middleware DTO
+	 * @return                     The middleware that was updated
+	 * @throws NotFoundException   Resource not found
+	 * @throws BadRequestException Only one middleware per version and api
+	 */
+	@Transactional
+	public Middleware update(Long apiId, Long middlewareId, MiddlewareDTO middlewareDTO) {
+
+		Middleware middleware = middlewareRepository.findByApiIdAndId(apiId, middlewareId);
+		HeimdallException.checkThrow(isBlank(middleware), GLOBAL_RESOURCE_NOT_FOUND);
+
+		Middleware resData = middlewareRepository.findByApiIdAndVersion(apiId, middlewareDTO.getVersion());
+		HeimdallException.checkThrow(notBlank(resData) && (resData.getApi().getId() == middleware.getApi().getId())
+				&& (resData.getId() != middleware.getId()), ONLY_ONE_MIDDLEWARE_PER_VERSION_AND_API);
+
+		middleware = GenericConverter.mapper(middlewareDTO, middleware);
+
+		if (middleware.getStatus().equals(Status.DEPRECATED))
+			middleware.setFile(null);
+
+		middleware = middlewareRepository.save(middleware);
+
+		amqpMiddlewareService.dispatchCreateMiddlewares(middlewareId);
+
+		return middleware;
+	}
+
+	/**
+	 * Deletes a middleware by API ID and middleware ID
+	 * 
+	 * @param apiId                The ID of the API
+	 * @param middlewareId         The middleware ID
+	 * @throws NotFoundException   Resource not found
+	 * @throws BadRequestException Middleware still contains interceptors associated
+	 */
+	@Transactional
+	public void delete(Long apiId, Long middlewareId) {
+
+		Middleware middleware = middlewareRepository.findByApiIdAndId(apiId, middlewareId);
+		HeimdallException.checkThrow(isBlank(middleware), GLOBAL_RESOURCE_NOT_FOUND);
+		HeimdallException.checkThrow(
+				(Objeto.notBlank(middleware.getInterceptors()) && middleware.getInterceptors().size() > 0),
+				ExceptionMessage.MIDDLEWARE_CONTAINS_INTERCEOPTORS);
+
+		amqpMiddlewareService.dispatchRemoveMiddlewares(middleware.getPath());
+		middlewareRepository.delete(middleware.getId());
+
+	}
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
@@ -183,6 +183,7 @@ public class MiddlewareService {
         		  .collect(Collectors.groupingBy(m -> m.getStatus()));
           
           Integer allowInactive = property.getMiddlewares().getAllowInactive();
+          Boolean deleteDeprecated = property.getMiddlewares().getDeleteDeprecated();
     	  
           if (Objeto.notBlank(allowInactive) && allowInactive != 0) {
         	    
@@ -195,7 +196,8 @@ public class MiddlewareService {
         	  
     		  inactive.stream().skip(allowInactive).forEach(m -> {
     			  m.setStatus(Status.DEPRECATED);
-    			  m.setFile(null);
+    			  if (Objeto.notBlank(deleteDeprecated) && deleteDeprecated)
+    				  m.setFile(null);
     		  });
         	  
           } else {
@@ -256,8 +258,11 @@ public class MiddlewareService {
           
           middleware = GenericConverter.mapper(middlewareDTO, middleware);
           
+          Boolean deleteDeprecated = property.getMiddlewares().getDeleteDeprecated();
+          
           if (middleware.getStatus().equals(Status.DEPRECATED))
-        	  middleware.setFile(null);
+        	  if (Objeto.notBlank(deleteDeprecated) && deleteDeprecated)
+        		  middleware.setFile(null);
           
           middleware = middlewareRepository.save(middleware);
           

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
@@ -182,9 +182,9 @@ public class MiddlewareService {
           Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
         		  .collect(Collectors.groupingBy(m -> m.getStatus()));
           
-          Integer rollbackLevels = property.getMiddlewares().getRollbackLevels();
+          Integer allowInactive = property.getMiddlewares().getAllowInactive();
     	  
-          if (Objeto.notBlank(rollbackLevels) && rollbackLevels != 0) {
+          if (Objeto.notBlank(allowInactive) && allowInactive != 0) {
         	    
         	  List<Middleware> active = middlewareMap.get(Status.ACTIVE);
         	  List<Middleware> inactive = middlewareMap.get(Status.INACTIVE);
@@ -193,7 +193,7 @@ public class MiddlewareService {
         	  inactive.addAll(active);
         	  inactive.sort((m1, m2) -> m2.getCreationDate().compareTo(m1.getCreationDate()));
         	  
-    		  inactive.stream().skip(rollbackLevels).forEach(m -> {
+    		  inactive.stream().skip(allowInactive).forEach(m -> {
     			  m.setStatus(Status.DEPRECATED);
     			  m.setFile(null);
     		  });

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -72,17 +72,17 @@ public class MiddlewareServiceTest {
 
 	@Mock
 	private AMQPMiddlewareService amqpMiddlewareService;
-
+	
 	@Mock
 	private Property property;
 
 	@Value("${zuul.filter.root}")
 	private String root;
-
+	
 	private Api api;
 	private List<Middleware> middlewareList;
 	private List<Interceptor> interceptors = new ArrayList<>();
-	private Middleware m1, m2, m3, m4, m5, middleware;
+	private Middleware m1, m2, m3, m4, m5, middleware;	
 	private Middlewares middlewareProperty;
 	private MiddlewareDTO middlewareDTO;
 	private MockMultipartFile multipartFile;
@@ -128,16 +128,16 @@ public class MiddlewareServiceTest {
 		middlewareList.add(m3);
 		middlewareList.add(m4);
 		middlewareList.add(m5);
-
+		
 		Property p = new Property();
 		middlewareProperty = p.getMiddlewares();
-
+		
 		middlewareDTO = new MiddlewareDTO();
 		middlewareDTO.setStatus(Status.ACTIVE);
 		middlewareDTO.setVersion("0.0.1");
 
-		multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar", "application/octet-stream",
-				"some content".getBytes());
+		multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar",
+				"application/octet-stream", "some content".getBytes());
 
 		middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
 		middleware.setApi(api);
@@ -150,11 +150,12 @@ public class MiddlewareServiceTest {
 			e.printStackTrace();
 		}
 
+		
 		Mockito.when(middlewareRepository.findByApiId(api.getId())).thenReturn(middlewareList);
 		Mockito.when(apiRepository.findOne(api.getId())).thenReturn(api);
 		Mockito.when(interceptorRepository.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, api.getId()))
 				.thenReturn(interceptors);
-
+		
 		Mockito.when(property.getMiddlewares()).thenReturn(middlewareProperty);
 
 		Mockito.when(middlewareRepository.save(middleware)).thenReturn(middleware);
@@ -165,58 +166,58 @@ public class MiddlewareServiceTest {
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m3.getId())).thenReturn(m3);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m4.getId())).thenReturn(m4);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m5.getId())).thenReturn(m5);
-
+		
 	}
 
 	@Test
 	public void saveNewMiddlewareTest() {
-
+		
 		middlewareProperty.setAllowInactive(1);
-
+		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
 		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
-
+		
 		assertTrue(saved.equals(middleware));
 		assertEquals(Status.ACTIVE, saved.getStatus());
 		assertEquals(1, middlewareMap.get(Status.INACTIVE).size());
 		assertEquals(4, middlewareMap.get(Status.DEPRECATED).size());
 
 	}
-
+	
 	@Test
 	public void saveNewMiddlewareNoRollbackTest() {
-
+		
 		middlewareProperty.setAllowInactive(null);
-
+		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
 		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
-
+		
 		assertTrue(saved.equals(middleware));
 		assertEquals(Status.ACTIVE, saved.getStatus());
 		assertEquals(3, middlewareMap.get(Status.INACTIVE).size());
 		assertEquals(2, middlewareMap.get(Status.DEPRECATED).size());
 
 	}
-
+	
 	@Test
 	public void saveNewMiddlewareHugeRollbackTest() {
-
+		
 		middlewareProperty.setAllowInactive(99999999);
-
+		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
 		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
-
+		
 		assertTrue(saved.equals(middleware));
 		assertEquals(Status.ACTIVE, saved.getStatus());
 		assertEquals(3, middlewareMap.get(Status.INACTIVE).size());
 		assertEquals(2, middlewareMap.get(Status.DEPRECATED).size());
 
 	}
-
+	
 }

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -28,6 +28,8 @@ import br.com.conductor.heimdall.core.entity.Interceptor;
 import br.com.conductor.heimdall.core.entity.Middleware;
 import br.com.conductor.heimdall.core.enums.Status;
 import br.com.conductor.heimdall.core.enums.TypeInterceptor;
+import br.com.conductor.heimdall.core.environment.Property;
+import br.com.conductor.heimdall.core.environment.Property.Middlewares;
 import br.com.conductor.heimdall.core.repository.ApiRepository;
 import br.com.conductor.heimdall.core.repository.InterceptorRepository;
 import br.com.conductor.heimdall.core.repository.MiddlewareRepository;
@@ -51,13 +53,22 @@ public class MiddlewareServiceTest {
 	@Mock
 	private AMQPMiddlewareService amqpMiddlewareService;
 	
-	@Value("${zuul.filter.root}")
-    private String root; 
+	@Mock
+	private Property property;
 
+	@Value("${zuul.filter.root}")
+	private String root;
+	
 	private Api api;
 	private List<Middleware> middlewares;
 	private List<Interceptor> interceptors = new ArrayList<>();
-	private Middleware m1, m2, m3, m4, m5;
+	private Middleware m1, m2, m3, m4, m5, middleware;
+	
+	private Property p;
+	private Middlewares middlewareProperty;
+	
+	private MiddlewareDTO middlewareDTO;
+	private MockMultipartFile multipartFile;
 
 	@Before
 	public void setUp() {
@@ -81,14 +92,13 @@ public class MiddlewareServiceTest {
 		m3.setApi(api);
 		m3.setId(30L);
 		m3.setCreationDate(LocalDateTime.of(2015, Month.JULY, 29, 19, 30, 40));
-		
+
 		m4 = new Middleware();
 		m4.setStatus(Status.DEPRECATED);
 		m4.setApi(api);
 		m4.setId(30L);
 		m4.setCreationDate(LocalDateTime.of(2014, Month.JULY, 29, 19, 30, 40));
-		
-		
+
 		m5 = new Middleware();
 		m5.setStatus(Status.DEPRECATED);
 		m5.setApi(api);
@@ -101,35 +111,38 @@ public class MiddlewareServiceTest {
 		middlewares.add(m3);
 		middlewares.add(m4);
 		middlewares.add(m5);
-
-	}
-
-	@Test
-	public void saveNewMiddlewareTest() {
-
-		MiddlewareDTO middlewareDTO = new MiddlewareDTO();
+		
+		
+		p = new Property();
+		middlewareProperty = p.getMiddlewares();
+		middlewareProperty.setRollbackLevels(0);
+		
+		middlewareDTO = new MiddlewareDTO();
 		middlewareDTO.setStatus(Status.ACTIVE);
 		middlewareDTO.setVersion("0.0.1");
-		
-		MockMultipartFile multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar",
+
+		multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar",
 				"application/octet-stream", "some content".getBytes());
-		
-		Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
-        middleware.setApi(api);
-        middleware.setPath(root + "/api/" + api.getId() + "/middleware");
-        middleware.setType("jar");
-        middleware.setStatus(Status.ACTIVE);
-        try {
+
+		middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
+		middleware.setApi(api);
+		middleware.setPath(root + "/api/" + api.getId() + "/middleware");
+		middleware.setType("jar");
+		middleware.setStatus(Status.ACTIVE);
+		try {
 			middleware.setFile(multipartFile.getBytes());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+
 		
 		Mockito.when(middlewareRepository.findByApiId(api.getId())).thenReturn(middlewares);
 		Mockito.when(apiRepository.findOne(api.getId())).thenReturn(api);
 		Mockito.when(interceptorRepository.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, api.getId()))
 				.thenReturn(interceptors);
 		
+		Mockito.when(property.getMiddlewares()).thenReturn(middlewareProperty);
+
 		Mockito.when(middlewareRepository.save(middleware)).thenReturn(middleware);
 		Mockito.when(middlewareRepository.save(middlewares)).thenReturn(middlewares);
 
@@ -138,33 +151,58 @@ public class MiddlewareServiceTest {
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m3.getId())).thenReturn(m3);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m4.getId())).thenReturn(m4);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m5.getId())).thenReturn(m5);
+		
+	}
 
+	@Test
+	public void saveNewMiddlewareTest() {
+		
+		middlewareProperty.setRollbackLevels(1);
+		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
-		
+
 		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
-      		  .collect(Collectors.groupingBy(m -> m.getStatus()));
-		
-		System.out.println(m1.getStatus());
-		System.out.println(m2.getStatus());
-		System.out.println(m3.getStatus());
-		System.out.println(m4.getStatus());
-		System.out.println(m5.getStatus());
+				.collect(Collectors.groupingBy(m -> m.getStatus()));
 		
 		assertTrue(saved.equals(middleware));
-		assertNull(middlewareMap.get(Status.ACTIVE));
-		assertEquals(2, middlewareMap.get(Status.INACTIVE).size());
-		assertEquals(3, middlewareMap.get(Status.DEPRECATED).size());
-		assertEquals(Status.DEPRECATED, m3.getStatus());
-		
+		assertEquals(Status.ACTIVE, saved.getStatus());
+		assertEquals(1, middlewareMap.get(Status.INACTIVE).size());
+		assertEquals(4, middlewareMap.get(Status.DEPRECATED).size());
+
 	}
 	
 	@Test
-	public void deprecateMiddleware() {
+	public void saveNewMiddlewareNoRollbackTest() {
 		
-		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m1.getId())).thenReturn(m1);
+		middlewareProperty.setRollbackLevels(null);
 		
-		Middleware modified = service.depreciate(api.getId(), m1.getId());
+		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
+
+		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+				.collect(Collectors.groupingBy(m -> m.getStatus()));
 		
-		assertTrue(modified.getStatus().equals(Status.DEPRECATED));
+		assertTrue(saved.equals(middleware));
+		assertEquals(Status.ACTIVE, saved.getStatus());
+		assertEquals(3, middlewareMap.get(Status.INACTIVE).size());
+		assertEquals(2, middlewareMap.get(Status.DEPRECATED).size());
+
 	}
+	
+	@Test
+	public void saveNewMiddlewareHugeRollbackTest() {
+		
+		middlewareProperty.setRollbackLevels(99999999);
+		
+		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
+
+		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+				.collect(Collectors.groupingBy(m -> m.getStatus()));
+		
+		assertTrue(saved.equals(middleware));
+		assertEquals(Status.ACTIVE, saved.getStatus());
+		assertEquals(3, middlewareMap.get(Status.INACTIVE).size());
+		assertEquals(2, middlewareMap.get(Status.DEPRECATED).size());
+
+	}
+	
 }

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -1,5 +1,25 @@
 package br.com.conductor.heimdall.core.service;
 
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -111,7 +131,6 @@ public class MiddlewareServiceTest {
 		
 		Property p = new Property();
 		middlewareProperty = p.getMiddlewares();
-		middlewareProperty.setRollbackLevels(0);
 		
 		middlewareDTO = new MiddlewareDTO();
 		middlewareDTO.setStatus(Status.ACTIVE);

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -172,7 +172,7 @@ public class MiddlewareServiceTest {
 	@Test
 	public void saveNewMiddlewareTest() {
 		
-		middlewareProperty.setRollbackLevels(1);
+		middlewareProperty.setAllowInactive(1);
 		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
@@ -189,7 +189,7 @@ public class MiddlewareServiceTest {
 	@Test
 	public void saveNewMiddlewareNoRollbackTest() {
 		
-		middlewareProperty.setRollbackLevels(null);
+		middlewareProperty.setAllowInactive(null);
 		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
@@ -206,7 +206,7 @@ public class MiddlewareServiceTest {
 	@Test
 	public void saveNewMiddlewareHugeRollbackTest() {
 		
-		middlewareProperty.setRollbackLevels(99999999);
+		middlewareProperty.setAllowInactive(99999999);
 		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -60,13 +60,10 @@ public class MiddlewareServiceTest {
 	private String root;
 	
 	private Api api;
-	private List<Middleware> middlewares;
+	private List<Middleware> middlewareList;
 	private List<Interceptor> interceptors = new ArrayList<>();
-	private Middleware m1, m2, m3, m4, m5, middleware;
-	
-	private Property p;
+	private Middleware m1, m2, m3, m4, m5, middleware;	
 	private Middlewares middlewareProperty;
-	
 	private MiddlewareDTO middlewareDTO;
 	private MockMultipartFile multipartFile;
 
@@ -96,24 +93,23 @@ public class MiddlewareServiceTest {
 		m4 = new Middleware();
 		m4.setStatus(Status.DEPRECATED);
 		m4.setApi(api);
-		m4.setId(30L);
+		m4.setId(40L);
 		m4.setCreationDate(LocalDateTime.of(2014, Month.JULY, 29, 19, 30, 40));
 
 		m5 = new Middleware();
 		m5.setStatus(Status.DEPRECATED);
 		m5.setApi(api);
-		m5.setId(30L);
+		m5.setId(50L);
 		m5.setCreationDate(LocalDateTime.of(2013, Month.JULY, 29, 19, 30, 40));
 
-		middlewares = new ArrayList<>();
-		middlewares.add(m1);
-		middlewares.add(m2);
-		middlewares.add(m3);
-		middlewares.add(m4);
-		middlewares.add(m5);
+		middlewareList = new ArrayList<>();
+		middlewareList.add(m1);
+		middlewareList.add(m2);
+		middlewareList.add(m3);
+		middlewareList.add(m4);
+		middlewareList.add(m5);
 		
-		
-		p = new Property();
+		Property p = new Property();
 		middlewareProperty = p.getMiddlewares();
 		middlewareProperty.setRollbackLevels(0);
 		
@@ -136,7 +132,7 @@ public class MiddlewareServiceTest {
 		}
 
 		
-		Mockito.when(middlewareRepository.findByApiId(api.getId())).thenReturn(middlewares);
+		Mockito.when(middlewareRepository.findByApiId(api.getId())).thenReturn(middlewareList);
 		Mockito.when(apiRepository.findOne(api.getId())).thenReturn(api);
 		Mockito.when(interceptorRepository.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, api.getId()))
 				.thenReturn(interceptors);
@@ -144,7 +140,7 @@ public class MiddlewareServiceTest {
 		Mockito.when(property.getMiddlewares()).thenReturn(middlewareProperty);
 
 		Mockito.when(middlewareRepository.save(middleware)).thenReturn(middleware);
-		Mockito.when(middlewareRepository.save(middlewares)).thenReturn(middlewares);
+		Mockito.when(middlewareRepository.save(middlewareList)).thenReturn(middlewareList);
 
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m1.getId())).thenReturn(m1);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m2.getId())).thenReturn(m2);
@@ -161,7 +157,7 @@ public class MiddlewareServiceTest {
 		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
-		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
 		
 		assertTrue(saved.equals(middleware));
@@ -178,7 +174,7 @@ public class MiddlewareServiceTest {
 		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
-		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
 		
 		assertTrue(saved.equals(middleware));
@@ -195,7 +191,7 @@ public class MiddlewareServiceTest {
 		
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
-		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
 		
 		assertTrue(saved.equals(middleware));

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -72,17 +72,17 @@ public class MiddlewareServiceTest {
 
 	@Mock
 	private AMQPMiddlewareService amqpMiddlewareService;
-	
+
 	@Mock
 	private Property property;
 
 	@Value("${zuul.filter.root}")
 	private String root;
-	
+
 	private Api api;
 	private List<Middleware> middlewareList;
 	private List<Interceptor> interceptors = new ArrayList<>();
-	private Middleware m1, m2, m3, m4, m5, middleware;	
+	private Middleware m1, m2, m3, m4, m5, middleware;
 	private Middlewares middlewareProperty;
 	private MiddlewareDTO middlewareDTO;
 	private MockMultipartFile multipartFile;
@@ -128,16 +128,16 @@ public class MiddlewareServiceTest {
 		middlewareList.add(m3);
 		middlewareList.add(m4);
 		middlewareList.add(m5);
-		
+
 		Property p = new Property();
 		middlewareProperty = p.getMiddlewares();
-		
+
 		middlewareDTO = new MiddlewareDTO();
 		middlewareDTO.setStatus(Status.ACTIVE);
 		middlewareDTO.setVersion("0.0.1");
 
-		multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar",
-				"application/octet-stream", "some content".getBytes());
+		multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar", "application/octet-stream",
+				"some content".getBytes());
 
 		middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
 		middleware.setApi(api);
@@ -150,12 +150,11 @@ public class MiddlewareServiceTest {
 			e.printStackTrace();
 		}
 
-		
 		Mockito.when(middlewareRepository.findByApiId(api.getId())).thenReturn(middlewareList);
 		Mockito.when(apiRepository.findOne(api.getId())).thenReturn(api);
 		Mockito.when(interceptorRepository.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, api.getId()))
 				.thenReturn(interceptors);
-		
+
 		Mockito.when(property.getMiddlewares()).thenReturn(middlewareProperty);
 
 		Mockito.when(middlewareRepository.save(middleware)).thenReturn(middleware);
@@ -166,58 +165,58 @@ public class MiddlewareServiceTest {
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m3.getId())).thenReturn(m3);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m4.getId())).thenReturn(m4);
 		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m5.getId())).thenReturn(m5);
-		
+
 	}
 
 	@Test
 	public void saveNewMiddlewareTest() {
-		
+
 		middlewareProperty.setAllowInactive(1);
-		
+
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
 		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
-		
+
 		assertTrue(saved.equals(middleware));
 		assertEquals(Status.ACTIVE, saved.getStatus());
 		assertEquals(1, middlewareMap.get(Status.INACTIVE).size());
 		assertEquals(4, middlewareMap.get(Status.DEPRECATED).size());
 
 	}
-	
+
 	@Test
 	public void saveNewMiddlewareNoRollbackTest() {
-		
+
 		middlewareProperty.setAllowInactive(null);
-		
+
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
 		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
-		
+
 		assertTrue(saved.equals(middleware));
 		assertEquals(Status.ACTIVE, saved.getStatus());
 		assertEquals(3, middlewareMap.get(Status.INACTIVE).size());
 		assertEquals(2, middlewareMap.get(Status.DEPRECATED).size());
 
 	}
-	
+
 	@Test
 	public void saveNewMiddlewareHugeRollbackTest() {
-		
+
 		middlewareProperty.setAllowInactive(99999999);
-		
+
 		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
 
 		Map<Status, List<Middleware>> middlewareMap = middlewareList.stream()
 				.collect(Collectors.groupingBy(m -> m.getStatus()));
-		
+
 		assertTrue(saved.equals(middleware));
 		assertEquals(Status.ACTIVE, saved.getStatus());
 		assertEquals(3, middlewareMap.get(Status.INACTIVE).size());
 		assertEquals(2, middlewareMap.get(Status.DEPRECATED).size());
 
 	}
-	
+
 }

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/MiddlewareServiceTest.java
@@ -1,0 +1,170 @@
+package br.com.conductor.heimdall.core.service;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mock.web.MockMultipartFile;
+
+import br.com.conductor.heimdall.core.converter.GenericConverter;
+import br.com.conductor.heimdall.core.dto.MiddlewareDTO;
+import br.com.conductor.heimdall.core.entity.Api;
+import br.com.conductor.heimdall.core.entity.Interceptor;
+import br.com.conductor.heimdall.core.entity.Middleware;
+import br.com.conductor.heimdall.core.enums.Status;
+import br.com.conductor.heimdall.core.enums.TypeInterceptor;
+import br.com.conductor.heimdall.core.repository.ApiRepository;
+import br.com.conductor.heimdall.core.repository.InterceptorRepository;
+import br.com.conductor.heimdall.core.repository.MiddlewareRepository;
+import br.com.conductor.heimdall.core.service.amqp.AMQPMiddlewareService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MiddlewareServiceTest {
+
+	@InjectMocks
+	private MiddlewareService service;
+
+	@Mock
+	private MiddlewareRepository middlewareRepository;
+
+	@Mock
+	private ApiRepository apiRepository;
+
+	@Mock
+	private InterceptorRepository interceptorRepository;
+
+	@Mock
+	private AMQPMiddlewareService amqpMiddlewareService;
+	
+	@Value("${zuul.filter.root}")
+    private String root; 
+
+	private Api api;
+	private List<Middleware> middlewares;
+	private List<Interceptor> interceptors = new ArrayList<>();
+	private Middleware m1, m2, m3, m4, m5;
+
+	@Before
+	public void setUp() {
+		api = new Api();
+		api.setId(10L);
+
+		m1 = new Middleware();
+		m1.setStatus(Status.ACTIVE);
+		m1.setApi(api);
+		m1.setId(10L);
+		m1.setCreationDate(LocalDateTime.of(2017, Month.JULY, 29, 19, 30, 40));
+
+		m2 = new Middleware();
+		m2.setStatus(Status.INACTIVE);
+		m2.setApi(api);
+		m2.setId(20L);
+		m2.setCreationDate(LocalDateTime.of(2016, Month.JULY, 29, 19, 30, 40));
+
+		m3 = new Middleware();
+		m3.setStatus(Status.INACTIVE);
+		m3.setApi(api);
+		m3.setId(30L);
+		m3.setCreationDate(LocalDateTime.of(2015, Month.JULY, 29, 19, 30, 40));
+		
+		m4 = new Middleware();
+		m4.setStatus(Status.DEPRECATED);
+		m4.setApi(api);
+		m4.setId(30L);
+		m4.setCreationDate(LocalDateTime.of(2014, Month.JULY, 29, 19, 30, 40));
+		
+		
+		m5 = new Middleware();
+		m5.setStatus(Status.DEPRECATED);
+		m5.setApi(api);
+		m5.setId(30L);
+		m5.setCreationDate(LocalDateTime.of(2013, Month.JULY, 29, 19, 30, 40));
+
+		middlewares = new ArrayList<>();
+		middlewares.add(m1);
+		middlewares.add(m2);
+		middlewares.add(m3);
+		middlewares.add(m4);
+		middlewares.add(m5);
+
+	}
+
+	@Test
+	public void saveNewMiddlewareTest() {
+
+		MiddlewareDTO middlewareDTO = new MiddlewareDTO();
+		middlewareDTO.setStatus(Status.ACTIVE);
+		middlewareDTO.setVersion("0.0.1");
+		
+		MockMultipartFile multipartFile = new MockMultipartFile("artifact", "strongbox-validate-8.1.jar",
+				"application/octet-stream", "some content".getBytes());
+		
+		Middleware middleware = GenericConverter.mapper(middlewareDTO, Middleware.class);
+        middleware.setApi(api);
+        middleware.setPath(root + "/api/" + api.getId() + "/middleware");
+        middleware.setType("jar");
+        middleware.setStatus(Status.ACTIVE);
+        try {
+			middleware.setFile(multipartFile.getBytes());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		
+		Mockito.when(middlewareRepository.findByApiId(api.getId())).thenReturn(middlewares);
+		Mockito.when(apiRepository.findOne(api.getId())).thenReturn(api);
+		Mockito.when(interceptorRepository.findByTypeAndOperationResourceApiId(TypeInterceptor.MIDDLEWARE, api.getId()))
+				.thenReturn(interceptors);
+		
+		Mockito.when(middlewareRepository.save(middleware)).thenReturn(middleware);
+		Mockito.when(middlewareRepository.save(middlewares)).thenReturn(middlewares);
+
+		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m1.getId())).thenReturn(m1);
+		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m2.getId())).thenReturn(m2);
+		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m3.getId())).thenReturn(m3);
+		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m4.getId())).thenReturn(m4);
+		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m5.getId())).thenReturn(m5);
+
+		Middleware saved = service.save(api.getId(), middlewareDTO, multipartFile);
+		
+		Map<Status, List<Middleware>> middlewareMap = middlewares.stream()
+      		  .collect(Collectors.groupingBy(m -> m.getStatus()));
+		
+		System.out.println(m1.getStatus());
+		System.out.println(m2.getStatus());
+		System.out.println(m3.getStatus());
+		System.out.println(m4.getStatus());
+		System.out.println(m5.getStatus());
+		
+		assertTrue(saved.equals(middleware));
+		assertNull(middlewareMap.get(Status.ACTIVE));
+		assertEquals(2, middlewareMap.get(Status.INACTIVE).size());
+		assertEquals(3, middlewareMap.get(Status.DEPRECATED).size());
+		assertEquals(Status.DEPRECATED, m3.getStatus());
+		
+	}
+	
+	@Test
+	public void deprecateMiddleware() {
+		
+		Mockito.when(middlewareRepository.findByApiIdAndId(api.getId(), m1.getId())).thenReturn(m1);
+		
+		Middleware modified = service.depreciate(api.getId(), m1.getId());
+		
+		assertTrue(modified.getStatus().equals(Status.DEPRECATED));
+	}
+}


### PR DESCRIPTION
### Added feature

Added a feature that gives the user the ability to set a Middleware the `DEPRECATED` status.
This status indicates that the middleware has a issue or is too old to be used.

This only applies to the versions of the same middleware.

Along with this status there is are two new properties that can be set in the `application.yml` :
```
middleware:
    allowInactive: Integer
    deleteDeprecated: Boolean
```
---
#### allowInactive
Handles how many middlewares should stay inactive, here is how it works.

When adding a new middleware:
* If not set or set to 0
  * Set the active middleware to inactive and add the new middleware
  * The status of all other middlewares will not be changed
* If set to `n`
  * Set the active middleware to inactive and add the new middleware
  * The status of the first `n` inactive middlewares will not be changed, any middleware older then that will be deprecated
---
#### deleteDeprecated
Indicates if the deprecated middleware file should be deleted from the database.
`true` deletes the files
`false` keep the files in the database.

Deprecated middlewares can only be recovered if the files are still in the database.