### PR TITLE
Should not delete deprecated

### DIFF
--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -80,7 +80,7 @@ heimdall:
             #userSearchFilter: sAMAccountName={0}    
     middlewares:
         allowInactive: 0
-        deleteDeprecated: true
+        deleteDeprecated: false
 
 spring:
     pid:


### PR DESCRIPTION
Default behavior should be not to delete deprecated middlewares to keep backwards compatibility