### PR TITLE
Fix cors duplicated

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/TraceConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/TraceConfiguration.java
@@ -1,4 +1,3 @@
-
 package br.com.conductor.heimdall.gateway.configuration;
 
 /*-
@@ -22,8 +21,6 @@ package br.com.conductor.heimdall.gateway.configuration;
  */
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -57,104 +54,101 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TraceConfiguration {
 
-     @Value("${info.app.profile}")
-     private String profile;
-     
-     @Value("${management.context-path}")
-     private String managerPath;
-     
-     @Autowired
-     private Property prop;
+	@Value("${info.app.profile}")
+	private String profile;
 
-     /**
-      * {@inheritDoc}
-      */
-     public class TraceFilter implements Filter {
-          private Map<String, String> cors;
-          @Override
-          public void destroy() { }
+	@Value("${management.context-path}")
+	private String managerPath;
 
-          @Override
-          public void doFilter(ServletRequest request, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+	@Autowired
+	private Property prop;
 
-               Trace trace = null;
+	/**
+	 * {@inheritDoc}
+	 */
+	public class TraceFilter implements Filter {
 
-               HttpServletResponse response = (HttpServletResponse) res;
-               try {
+		@Override
+		public void destroy() {
+		}
 
-                    trace = TraceContextHolder.getInstance().init(prop.getTrace().isPrintAllTrace(), profile, request, prop.getMongo().getEnabled());
-                    if (shouldDisableTrace(request)) {
-                         TraceContextHolder.getInstance().disablePrint();
-                    }
-                    
-                    cors.entrySet().stream()
-                         .filter(entry -> !response.containsHeader(entry.getKey()))
-                         .forEach(entry -> response.addHeader(entry.getKey(), entry.getValue()));
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse res, FilterChain chain) throws IOException, ServletException {
 
-                    if ("OPTIONS".equalsIgnoreCase(((HttpServletRequest) request).getMethod())) {
-                         response.setStatus(200);
-                    } else {
-                         //chain.doFilter(request, response);
-                         chain.doFilter(request, response);
-                    }
-                    
-               } catch (Exception e) {
-                    
-                    log.error("Error {} during request {} exception {}", e.getMessage(), ((HttpServletRequest) request).getRequestURL(), e);
-               } finally {
+			Trace trace = null;
 
-                    if (TraceContextHolder.getInstance().shouldWrite()) {
+			HttpServletResponse response = (HttpServletResponse) res;
+			try {
 
-                         if (trace != null) {
-                              trace.write(response);
-                         }
-                    } else {
-                         TraceContextHolder.getInstance().clearActual();
-                    }
-                    TraceContextHolder.getInstance().unset();
-                    
-               }
-          }
+				trace = TraceContextHolder.getInstance().init(prop.getTrace().isPrintAllTrace(), profile, request, prop.getMongo().getEnabled());
+				if (shouldDisableTrace(request)) {
+					TraceContextHolder.getInstance().disablePrint();
+				}
 
-          @Override
-          public void init(FilterConfig arg0) throws ServletException {
-               this.cors = new HashMap<>();
-               this.cors.put("Access-Control-Allow-Origin", "*");
-               this.cors.put("Access-Control-Allow-Credentials", "true");
-               this.cors.put("Access-Control-Allow-Methods", "POST, GET, PUT, PATCH, DELETE, OPTIONS");
-               this.cors.put("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, x-requested-with, X-AUTH-TOKEN, access_token, client_id, device_id, credential");
-               this.cors.put("Access-Control-Max-Age", "3600");
-          }
+				if ("OPTIONS".equalsIgnoreCase(((HttpServletRequest) request).getMethod())) {
+					response.setHeader("Access-Control-Allow-Origin", "*");
+					response.setHeader("Access-Control-Allow-Credentials", "true");
+					response.setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, PATCH, DELETE, OPTIONS");
+					response.setHeader("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, x-requested-with, X-AUTH-TOKEN, access_token, client_id, device_id, credential");
+					response.setHeader("Access-Control-Max-Age", "3600");
+					response.setStatus(200);
+				} else {
+					chain.doFilter(request, response);
+				}
+				
 
-     }
+			} catch (Exception e) {
 
-     /**
-      * Checks if it should disable the Trace from a c.
-      * 
-      * @param request		{@link ServletRequest}
-      * @return				True if trace should be disable, false otherwise
-      */
-     public boolean shouldDisableTrace(ServletRequest request) {
+				log.error("Error {} during request {} exception {}", e.getMessage(), ((HttpServletRequest) request).getRequestURL(), e);
+			} finally {
 
-          String uri = ((HttpServletRequest) request).getRequestURI();
-          return (uri.equalsIgnoreCase("/") || uri.startsWith(managerPath));
-     }
+				if (TraceContextHolder.getInstance().shouldWrite()) {
 
-     /**
-      * Configures and returns the {@link FilterRegistrationBean}.
-      * 
-      * @return {@link FilterRegistrationBean}
-      */
-     @Bean
-     public FilterRegistrationBean filterRegistrationBean() {
+					if (trace != null) {
+						trace.write(response);
+					}
+				} else {
+					TraceContextHolder.getInstance().clearActual();
+				}
+				TraceContextHolder.getInstance().unset();
+			}
+		}
 
-          FilterRegistrationBean filtroRestAuth = new FilterRegistrationBean();
-          filtroRestAuth.setFilter(new TraceFilter());
-          filtroRestAuth.addUrlPatterns("/*");
-          filtroRestAuth.setOrder(Ordered.HIGHEST_PRECEDENCE);
-          filtroRestAuth.setName("traceFilter");
+		@Override
+		public void init(FilterConfig arg0) throws ServletException {
+			
+		}
 
-          return filtroRestAuth;
-     }
+	}
+
+	/**
+	 * Checks if it should disable the Trace from a c.
+	 * 
+	 * @param request
+	 *            {@link ServletRequest}
+	 * @return True if trace should be disable, false otherwise
+	 */
+	public boolean shouldDisableTrace(ServletRequest request) {
+
+		String uri = ((HttpServletRequest) request).getRequestURI();
+		return (uri.equalsIgnoreCase("/") || uri.startsWith(managerPath));
+	}
+
+	/**
+	 * Configures and returns the {@link FilterRegistrationBean}.
+	 * 
+	 * @return {@link FilterRegistrationBean}
+	 */
+	@Bean
+	public FilterRegistrationBean filterRegistrationBean() {
+
+		FilterRegistrationBean filtroRestAuth = new FilterRegistrationBean();
+		filtroRestAuth.setFilter(new TraceFilter());
+		filtroRestAuth.addUrlPatterns("/*");
+		filtroRestAuth.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		filtroRestAuth.setName("traceFilter");
+
+		return filtroRestAuth;
+	}
 
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CorsFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CorsFilter.java
@@ -1,0 +1,91 @@
+package br.com.conductor.heimdall.gateway.filter;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletResponse;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
+import org.springframework.stereotype.Component;
+
+import com.netflix.util.Pair;
+import com.netflix.zuul.context.RequestContext;
+
+/**
+ * 
+ * @author marcos.filho
+ *
+ */
+
+@Component
+public class CorsFilter extends HeimdallFilter {
+
+	private Map<String, String> cors;
+
+	public CorsFilter() {
+		this.cors = new HashMap<>();
+		this.cors.put("Access-Control-Allow-Origin", "*");
+		this.cors.put("Access-Control-Allow-Credentials", "true");
+		this.cors.put("Access-Control-Allow-Methods", "POST, GET, PUT, PATCH, DELETE, OPTIONS");
+		this.cors.put("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, x-requested-with, X-AUTH-TOKEN, access_token, client_id, device_id, credential");
+		this.cors.put("Access-Control-Max-Age", "3600");
+	}
+
+	@Override
+	public boolean should() {
+		return true;
+	}
+
+	@Override
+	public void execute() throws Throwable {
+		RequestContext ctx = RequestContext.getCurrentContext();
+
+		HttpServletResponse response = ctx.getResponse();
+		List<Pair<String, String>> zuulResponseHeaders = ctx.getZuulResponseHeaders();
+		
+		List<String> headersFromResponse = zuulResponseHeaders.stream().map(pair -> pair.first()).collect(Collectors.toList());
+		
+		cors.entrySet()
+			.stream()
+			.filter(entry -> !headersFromResponse.contains(entry.getKey()))
+			.forEach(entry -> response.setHeader(entry.getKey(), entry.getValue()));
+		
+	}
+
+	@Override
+	public String getName() {
+		return "CORSFilter";
+	}
+
+	@Override
+	public int filterOrder() {
+		return 101;
+	}
+
+	@Override
+	public String filterType() {
+		return POST_TYPE;
+	}
+
+}


### PR DESCRIPTION
*Fix cors problem when the backend send cors too.

When the backend send the cors implementation then the heimdall add headers to the response duplicating the headers necessary, with this PR we check if the header are present in the response and if true we don't put the CORS implemented by heimdall to the response