### PR TITLE
Add objects in payload of the token

### DIFF
--- a/heimdall-api/src/main/java/br/com/conductor/heimdall/api/resource/ProviderResource.java
+++ b/heimdall-api/src/main/java/br/com/conductor/heimdall/api/resource/ProviderResource.java
@@ -70,7 +70,7 @@ public class ProviderResource {
      * @return {@link ResponseEntity}
      */
     @ResponseBody
-    @ApiOperation(value = "Save a nem provider")
+    @ApiOperation(value = "Save a new provider")
     @PostMapping
     @PreAuthorize(ConstantsPrivilege.PRIVILEGE_CREATE_PROVIDER)
     public ResponseEntity<?> save(@RequestBody ProviderDTO providerPersist) {

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OAuthService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OAuthService.java
@@ -21,9 +21,11 @@ package br.com.conductor.heimdall.core.service;
  */
 
 import java.util.Base64;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -67,44 +69,49 @@ public class OAuthService {
      * @throws UnauthorizedException Token expired or code already used
      * @throws BadRequestException   Code not found or GrantType not informed
      */
-    public TokenOAuth generateToken(OAuthRequest oAuthRequest, String privateKey, int timeAccessToken, int timeRefreshToken) throws UnauthorizedException, BadRequestException {
+    public TokenOAuth generateToken(OAuthRequest oAuthRequest, String privateKey, int timeAccessToken, int timeRefreshToken, String claimsObject) throws UnauthorizedException, BadRequestException {
 
         TokenOAuth tokenOAuth;
 
-        if (oAuthRequest.getGrantType().toUpperCase().equals(GRANT_TYPE_PASSWORD)) {
+        switch (oAuthRequest.getGrantType().toUpperCase()) {
+            case GRANT_TYPE_PASSWORD:
 
-            if (Objeto.notBlank(oAuthRequest.getCode())) {
-                String decodedCode = new String(Base64.getDecoder().decode(oAuthRequest.getCode()));
-                String clientId = decodedCode.split("::")[1];
+                if (Objeto.notBlank(oAuthRequest.getCode())) {
+                    String decodedCode = new String(Base64.getDecoder().decode(oAuthRequest.getCode()));
+                    String clientId = decodedCode.split("::")[1];
 
-                OAuthAuthorize foundCode = oAuthAuthorizeRepository.findOne(clientId);
+                    OAuthAuthorize foundCode = oAuthAuthorizeRepository.findOne(clientId);
 
-                if (Objeto.notBlank(foundCode)) {
-                    if (foundCode.getTokenAuthorize().equals(oAuthRequest.getCode())) {
-                        tokenOAuth = jwtUtils.generateNewToken(privateKey, oAuthRequest.getOperations(), timeAccessToken, timeRefreshToken);
-                        oAuthAuthorizeRepository.delete(foundCode);
+                    if (Objeto.notBlank(foundCode)) {
+                        if (foundCode.getTokenAuthorize().equals(oAuthRequest.getCode())) {
+                            final Map<String, Object> claimsFromJSONObjectBodyRequest = jwtUtils.getClaimsFromJSONObjectBodyRequest(claimsObject);
+                            tokenOAuth = jwtUtils.generateNewToken(privateKey, oAuthRequest.getOperations(), timeAccessToken, timeRefreshToken, claimsFromJSONObjectBodyRequest);
+                            oAuthAuthorizeRepository.delete(foundCode);
+                        } else {
+                            throw new BadRequestException(ExceptionMessage.CODE_NOT_FOUND);
+                        }
                     } else {
                         throw new BadRequestException(ExceptionMessage.CODE_NOT_FOUND);
                     }
                 } else {
                     throw new BadRequestException(ExceptionMessage.CODE_NOT_FOUND);
                 }
-            } else {
-                throw new BadRequestException(ExceptionMessage.CODE_NOT_FOUND);
-            }
 
-        } else if (oAuthRequest.getGrantType().toUpperCase().equals(GRANT_TYPE_REFRESH_TOKEN)) {
-            if (Objeto.isBlank(oAuthRequest.getRefreshToken())) {
-                throw new BadRequestException(ExceptionMessage.REFRESH_TOKEN_NOT_EXIST);
-            }
-            boolean tokenExpired = jwtUtils.tokenExpired(oAuthRequest.getRefreshToken(), privateKey);
-            if (tokenExpired) {
-                throw new UnauthorizedException(ExceptionMessage.TOKEN_EXPIRED);
-            } else {
-                tokenOAuth = jwtUtils.generateNewToken(privateKey, oAuthRequest.getOperations(), timeAccessToken, timeRefreshToken);
-            }
-        } else {
-            throw new BadRequestException(ExceptionMessage.GRANT_TYPE_NOT_EXIST);
+                break;
+            case GRANT_TYPE_REFRESH_TOKEN:
+                if (Objeto.isBlank(oAuthRequest.getRefreshToken())) {
+                    throw new BadRequestException(ExceptionMessage.REFRESH_TOKEN_NOT_EXIST);
+                }
+                boolean tokenExpired = jwtUtils.tokenExpired(oAuthRequest.getRefreshToken(), privateKey);
+                if (tokenExpired) {
+                    throw new UnauthorizedException(ExceptionMessage.TOKEN_EXPIRED);
+                } else {
+                    final Map<String, Object> claimsFromJSONObjectBodyRequest = jwtUtils.getClaimsFromJSONObjectBodyRequest(claimsObject);
+                    tokenOAuth = jwtUtils.generateNewToken(privateKey, oAuthRequest.getOperations(), timeAccessToken, timeRefreshToken, claimsFromJSONObjectBodyRequest);
+                }
+                break;
+            default:
+                throw new BadRequestException(ExceptionMessage.GRANT_TYPE_NOT_EXIST);
         }
 
         return tokenOAuth;

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OAuthService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OAuthService.java
@@ -65,6 +65,7 @@ public class OAuthService {
      * @param oAuthRequest     The {@link OAuthRequest}
      * @param timeAccessToken  The time to expire the accessToken
      * @param timeRefreshToken The time to expire the RefreshToken
+     * @param claimsObject     The claimsObject in {@link String}
      * @return The {@link TokenOAuth}
      * @throws UnauthorizedException Token expired or code already used
      * @throws BadRequestException   Code not found or GrantType not informed

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/ConstantsPath.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/ConstantsPath.java
@@ -71,6 +71,6 @@ public class ConstantsPath {
      
      public static final String PATH_PRIVILEGES = PATH_API + "/privileges";
      
-     public static final String PATH_PROVIDER = PATH_API + "/provider";
+     public static final String PATH_PROVIDER = PATH_API + "/providers";
      
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/JwtUtils.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/JwtUtils.java
@@ -20,16 +20,16 @@ package br.com.conductor.heimdall.core.util;
  * ==========================LICENSE_END===================================
  */
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
 import br.com.conductor.heimdall.core.entity.TokenOAuth;
@@ -57,8 +57,8 @@ public class JwtUtils {
      * @param timeRefreshToken Time to expire the refreshToken
      * @return The new {@link TokenOAuth}
      */
-    public TokenOAuth generateNewToken(String privateKey, Set<String> operationsPath, int timeToken, int timeRefreshToken) {
-        return generateToken(privateKey, timeToken, timeRefreshToken, operationsPath);
+    public TokenOAuth generateNewToken(String privateKey, Set<String> operationsPath, int timeToken, int timeRefreshToken, Map<String, Object> claims) {
+        return generateToken(privateKey, timeToken, timeRefreshToken, operationsPath, claims);
     }
 
     /**
@@ -68,8 +68,8 @@ public class JwtUtils {
      * @param operationsPath Paths that the token can be used
      * @return The new {@link TokenOAuth}
      */
-    public TokenOAuth generateNewTokenTimeDefault(String privateKey, Set<String> operationsPath) {
-        return generateToken(privateKey, 20, 3600, operationsPath);
+    public TokenOAuth generateNewTokenTimeDefault(String privateKey, Set<String> operationsPath, Map<String, Object> claims) {
+        return generateToken(privateKey, 20, 3600, operationsPath, claims);
     }
 
     /**
@@ -115,6 +115,19 @@ public class JwtUtils {
         return operations;
     }
 
+    public Map<String, Object> getClaimsFromJSONObjectBodyRequest(String jsonObject) {
+
+        Map<String, Object> claims = new HashMap<>();
+
+        try {
+            claims = new ObjectMapper().readValue(jsonObject, HashMap.class);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return claims;
+    }
+
     /**
      * This method generate a new token.
      *
@@ -124,7 +137,7 @@ public class JwtUtils {
      * @param timeRefreshToken Time to expire the refreshToken
      * @return The new {@link TokenOAuth}
      */
-    private TokenOAuth generateToken(String privateKey, int timeToken, int timeRefreshToken, Set<String> operationsPath) {
+    private TokenOAuth generateToken(String privateKey, int timeToken, int timeRefreshToken, Set<String> operationsPath, Map<String, Object> claims) {
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime dateExpiredAccessToken = now.plusSeconds(timeToken);
         final LocalDateTime dateExpiredRefreshToken = now.plusSeconds(timeRefreshToken);
@@ -133,6 +146,7 @@ public class JwtUtils {
         String accessToken = Jwts.builder()
                 .setExpiration(Date.from(dateExpiredAccessToken.atZone(ZoneId.systemDefault()).toInstant()))
                 .claim("operations", operationsPath)
+                .addClaims(claims)
                 .signWith(
                         SignatureAlgorithm.HS256,
                         secretKey
@@ -141,6 +155,7 @@ public class JwtUtils {
         String refreshToken = Jwts.builder()
                 .setExpiration(Date.from(dateExpiredRefreshToken.atZone(ZoneId.systemDefault()).toInstant()))
                 .claim("operations", operationsPath)
+                .addClaims(claims)
                 .signWith(
                         SignatureAlgorithm.HS256,
                         secretKey
@@ -186,5 +201,41 @@ public class JwtUtils {
      */
     private String getSecretKeyByClientId(String privateKey) {
         return Base64.getEncoder().encodeToString(privateKey.getBytes());
+    }
+
+    private static Map<String, Object> toMap(JSONObject object) throws JSONException {
+        Map<String, Object> map = new HashMap<String, Object>();
+
+        Iterator<String> keysItr = object.keys();
+        while(keysItr.hasNext()) {
+            String key = keysItr.next();
+            Object value = object.get(key);
+
+            if(value instanceof JSONArray) {
+                value = toList((JSONArray) value);
+            }
+
+            else if(value instanceof JSONObject) {
+                value = toMap((JSONObject) value);
+            }
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    public static List<Object> toList(JSONArray array) throws JSONException {
+        List<Object> list = new ArrayList<Object>();
+        for(int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if(value instanceof JSONArray) {
+                value = toList((JSONArray) value);
+            }
+
+            else if(value instanceof JSONObject) {
+                value = toMap((JSONObject) value);
+            }
+            list.add(value);
+        }
+        return list;
     }
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/JwtUtils.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/JwtUtils.java
@@ -55,6 +55,7 @@ public class JwtUtils {
      * @param operationsPath   Paths that the token can be used
      * @param timeToken        Time to expire the accessToken
      * @param timeRefreshToken Time to expire the refreshToken
+     * @param claims           The {@link Map}<{@link String}, {@link Object}> claims
      * @return The new {@link TokenOAuth}
      */
     public TokenOAuth generateNewToken(String privateKey, Set<String> operationsPath, int timeToken, int timeRefreshToken, Map<String, Object> claims) {
@@ -66,6 +67,7 @@ public class JwtUtils {
      *
      * @param privateKey     The privateKey that is used to get the SecretKey
      * @param operationsPath Paths that the token can be used
+     * @param claims         The {@link Map}<{@link String}, {@link Object}> claims
      * @return The new {@link TokenOAuth}
      */
     public TokenOAuth generateNewTokenTimeDefault(String privateKey, Set<String> operationsPath, Map<String, Object> claims) {
@@ -115,6 +117,12 @@ public class JwtUtils {
         return operations;
     }
 
+    /**
+     * Convert JsonObject to {@link Map}<{@link String}, {@link Object}>
+     *
+     * @param jsonObject The JsonObject
+     * @return {@link Map}<{@link String}, {@link Object}>
+     */
     public Map<String, Object> getClaimsFromJSONObjectBodyRequest(String jsonObject) {
 
         Map<String, Object> claims = new HashMap<>();
@@ -131,10 +139,11 @@ public class JwtUtils {
     /**
      * This method generate a new token.
      *
-     * @param privateKey         The privateKey that is used to get the SecretKey
+     * @param privateKey       The privateKey that is used to get the SecretKey
      * @param operationsPath   Paths that the token can be used
      * @param timeToken        Time to expire the accessToken
      * @param timeRefreshToken Time to expire the refreshToken
+     * @param claims           The {@link Map}<{@link String}, {@link Object}> claims
      * @return The new {@link TokenOAuth}
      */
     private TokenOAuth generateToken(String privateKey, int timeToken, int timeRefreshToken, Set<String> operationsPath, Map<String, Object> claims) {
@@ -207,15 +216,13 @@ public class JwtUtils {
         Map<String, Object> map = new HashMap<String, Object>();
 
         Iterator<String> keysItr = object.keys();
-        while(keysItr.hasNext()) {
+        while (keysItr.hasNext()) {
             String key = keysItr.next();
             Object value = object.get(key);
 
-            if(value instanceof JSONArray) {
+            if (value instanceof JSONArray) {
                 value = toList((JSONArray) value);
-            }
-
-            else if(value instanceof JSONObject) {
+            } else if (value instanceof JSONObject) {
                 value = toMap((JSONObject) value);
             }
             map.put(key, value);
@@ -225,13 +232,11 @@ public class JwtUtils {
 
     public static List<Object> toList(JSONArray array) throws JSONException {
         List<Object> list = new ArrayList<Object>();
-        for(int i = 0; i < array.length(); i++) {
+        for (int i = 0; i < array.length(); i++) {
             Object value = array.get(i);
-            if(value instanceof JSONArray) {
+            if (value instanceof JSONArray) {
                 value = toList((JSONArray) value);
-            }
-
-            else if(value instanceof JSONObject) {
+            } else if (value instanceof JSONObject) {
                 value = toMap((JSONObject) value);
             }
             list.add(value);


### PR DESCRIPTION
**Describe feature**
Implementation of the add objects in payload of a token JWT, when  it sends a request to OAuth GENERATE, add javadoc and show error when client_id is not found in request to OAuth AUTHORIZE.