### PR TITLE
[Grammarfix] Fixed misspelled "groovy" in log for listener

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/listener/StartServer.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/listener/StartServer.java
@@ -95,7 +95,7 @@ public class StartServer implements ServletContextListener {
      @Override
      public void contextInitialized(ServletContextEvent sce) {
 
-          log.info("Initializing Goovy Interceptors");
+          log.info("Initializing Groovy Interceptors");
           initGroovyFilterManager();
 
      }


### PR DESCRIPTION
During Gateway startup the log shows:
* "Initializing Goovy Interceptors"

Should be:
* "Initializing Groovy Interceptors"