### PR TITLE
Date serialization

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/spec/Json.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/spec/Json.java
@@ -3,7 +3,7 @@ package br.com.conductor.heimdall.core.spec;
 
 /*-
  * =========================LICENSE_START==================================
- * heimdall-middleware-spec
+ * heimdall-core
  * ========================================================================
  * Copyright (C) 2018 Conductor Tecnologia SA
  * ========================================================================

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/spec/StackTrace.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/spec/StackTrace.java
@@ -3,7 +3,7 @@ package br.com.conductor.heimdall.core.spec;
 
 /*-
  * =========================LICENSE_START==================================
- * heimdall-middleware-spec
+ * heimdall-core
  * ========================================================================
  * Copyright (C) 2018 Conductor Tecnologia SA
  * ========================================================================

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/LocalDateTimeSerializer.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/LocalDateTimeSerializer.java
@@ -40,8 +40,6 @@ public class LocalDateTimeSerializer extends JsonSerializer<TemporalAccessor> {
 
      private static final DateTimeFormatter ISOFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.systemDefault());
 
-     public static final LocalDateTimeSerializer INSTANCE = new LocalDateTimeSerializer();
-
      LocalDateTimeSerializer(){}
 
      @Override

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/GeneralTrace.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/GeneralTrace.java
@@ -21,8 +21,11 @@ package br.com.conductor.heimdall.gateway.trace;
  * ==========================LICENSE_END===================================
  */
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
+import br.com.conductor.heimdall.core.util.LocalDateTimeSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
 
 /**
@@ -35,8 +38,9 @@ import lombok.Data;
 public class GeneralTrace {
 
      private String description;
-     
-     private String insertedOnDate = br.com.twsoftware.alfred.data.Data.getDataFormatada(new Date(), "dd/MM/yyyy hh:mm:ss.SSS");
+
+     @JsonSerialize(using = LocalDateTimeSerializer.class)
+     private LocalDateTime insertedOnDate = LocalDateTime.now();
 
      private Object content;
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
@@ -23,7 +23,7 @@ package br.com.conductor.heimdall.gateway.trace;
 
 import static net.logstash.logback.marker.Markers.append;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.Enumeration;
 import java.util.List;
 
@@ -31,6 +31,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import br.com.conductor.heimdall.core.util.LocalDateTimeSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +75,8 @@ public class Trace {
 
      private Long durationMillis;
 
-     private String insertedOnDate = br.com.twsoftware.alfred.data.Data.getDataFormatada(new Date(), "dd/MM/yyyy hh:mm:ss.SSS");
+     @JsonSerialize(using = LocalDateTimeSerializer.class)
+     private LocalDateTime insertedOnDate = LocalDateTime.now();
 
      private Long apiId;
 
@@ -132,7 +135,7 @@ public class Trace {
           this.printAllTrace = printAllTrace;
           this.printMongo = printMongo;
           HttpServletRequest request = (HttpServletRequest) servletRequest;
-          HeimdallException.checkThrow(request == null ? true : false, ExceptionMessage.GLOBAL_REQUEST_NOT_FOUND);
+          HeimdallException.checkThrow(request == null, ExceptionMessage.GLOBAL_REQUEST_NOT_FOUND);
 
           setInitialTime(System.currentTimeMillis());
           setMethod(request.getMethod());
@@ -143,7 +146,7 @@ public class Trace {
 
                List<String> listaIPs = Lists.newArrayList();
                while (headers.hasMoreElements()) {
-                    String ip = (String) headers.nextElement();
+                    String ip = headers.nextElement();
                     listaIPs.add(ip);
                }
 


### PR DESCRIPTION
The way that Heimdall saved the date for the logs was not ISO 8601-compliant. That meant that searches with mongodb were not correct.

This pull request makes sure that the date is saved correctly in mongodb