### PR TITLE
Remove header from middleware helper not working

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
@@ -648,7 +648,7 @@ public class CallImpl implements Call {
 
                     List<String> names = Collections.list(super.getHeaderNames());
                     
-                    if (Objeto.notBlank(name) && !names.stream().filter(s -> s.equalsIgnoreCase(name)).findFirst().isPresent()) {
+                    if (Objeto.notBlank(name) && names.stream().anyMatch(s -> s.equalsIgnoreCase(name))) {
                          
                          names.remove(name);
                     }


### PR DESCRIPTION
**Describe the bug**
The method to remove headers from Helper class that is used by the middlewares was not working properly.

The issue was a wrong condition. It was the _not_ before the check that was causing the problem.

Also replaced `.findFirst().isPresent()` for a `.anyMatch` to improve readability.