### PR TITLE
Restrict adding environments with equal inbound url in API

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/exception/ExceptionMessage.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/exception/ExceptionMessage.java
@@ -83,7 +83,9 @@ public enum ExceptionMessage {
      API_BASEPATH_EXIST(BAD_REQUEST.value(), "The basepath defined exist", BadRequestException.class),
      
      API_BASEPATH_EMPTY(BAD_REQUEST.value(), "Basepath not defined", BadRequestException.class),
-     
+
+     API_CANT_ENVIRONMENT_INBOUND_URL_EQUALS(BAD_REQUEST.value(), "Apis can't have environments with the same inbound url", BadRequestException.class),
+
      ONLY_ONE_OPERATION_PER_RESOURCE(BAD_REQUEST.value(), "Only one operation per resource", BadRequestException.class),
 
      ONLY_ONE_RESOURCE_PER_API(BAD_REQUEST.value(), "Only one resource per api", BadRequestException.class),

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/ApiService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/ApiService.java
@@ -10,9 +10,9 @@ package br.com.conductor.heimdall.core.service;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,16 +21,20 @@ package br.com.conductor.heimdall.core.service;
  * ==========================LICENSE_END===================================
  */
 
-import static br.com.conductor.heimdall.core.exception.ExceptionMessage.API_BASEPATH_EXIST;
-import static br.com.conductor.heimdall.core.exception.ExceptionMessage.GLOBAL_RESOURCE_NOT_FOUND;
-import static br.com.conductor.heimdall.core.exception.ExceptionMessage.API_BASEPATH_MALFORMED;
-import static br.com.conductor.heimdall.core.exception.ExceptionMessage.API_BASEPATH_EMPTY;
-import static br.com.twsoftware.alfred.object.Objeto.isBlank;
-import static br.com.twsoftware.alfred.object.Objeto.notBlank;
-
-import java.util.Arrays;
-import java.util.List;
-
+import br.com.conductor.heimdall.core.converter.ApiMap;
+import br.com.conductor.heimdall.core.converter.GenericConverter;
+import br.com.conductor.heimdall.core.dto.ApiDTO;
+import br.com.conductor.heimdall.core.dto.PageDTO;
+import br.com.conductor.heimdall.core.dto.PageableDTO;
+import br.com.conductor.heimdall.core.dto.ReferenceIdDTO;
+import br.com.conductor.heimdall.core.dto.page.ApiPage;
+import br.com.conductor.heimdall.core.entity.Api;
+import br.com.conductor.heimdall.core.entity.Environment;
+import br.com.conductor.heimdall.core.exception.HeimdallException;
+import br.com.conductor.heimdall.core.repository.ApiRepository;
+import br.com.conductor.heimdall.core.service.amqp.AMQPRouteService;
+import br.com.conductor.heimdall.core.util.Pageable;
+import br.com.twsoftware.alfred.object.Objeto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
@@ -38,23 +42,21 @@ import org.springframework.data.domain.ExampleMatcher.StringMatcher;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
-import br.com.conductor.heimdall.core.converter.ApiMap;
-import br.com.conductor.heimdall.core.converter.GenericConverter;
-import br.com.conductor.heimdall.core.dto.ApiDTO;
-import br.com.conductor.heimdall.core.dto.PageDTO;
-import br.com.conductor.heimdall.core.dto.PageableDTO;
-import br.com.conductor.heimdall.core.dto.page.ApiPage;
-import br.com.conductor.heimdall.core.entity.Api;
-import br.com.conductor.heimdall.core.exception.HeimdallException;
-import br.com.conductor.heimdall.core.repository.ApiRepository;
-import br.com.conductor.heimdall.core.service.amqp.AMQPRouteService;
-import br.com.conductor.heimdall.core.util.Pageable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static br.com.conductor.heimdall.core.exception.ExceptionMessage.*;
+import static br.com.twsoftware.alfred.object.Objeto.isBlank;
+import static br.com.twsoftware.alfred.object.Objeto.notBlank;
 
 /**
  * This class provides methods to create, read, update and delete the {@link Api} resource.
- * 
- * @author Filipe Germano
  *
+ * @author Filipe Germano
+ * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
  */
 @Service
 public class ApiService {
@@ -65,24 +67,27 @@ public class ApiService {
      @Autowired
      private AMQPRouteService amqpRoute;
 
+     @Autowired
+     private EnvironmentService environmentService;
+
      /**
       * Finds a {@link Api} by its ID.
-      * 
+      *
       * @param 	id						The ID of the {@link Api}
       * @return							The {@link Api}
       * @throws	NotFoundException		Resource not found
       */
      public Api find(Long id) {
-          
-          Api api = apiRepository.findOne(id);      
+
+          Api api = apiRepository.findOne(id);
           HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
-                              
+
           return api;
      }
-     
+
      /**
       * Generates a paged list of the {@link Api}'s
-      * 
+      *
       * @param 	apiDTO					{@link ApiDTO}
       * @param 	pageableDTO				{@link PageableDTO}
       * @return 						The paged {@link Api} list as a {@link ApiPage} object
@@ -90,38 +95,38 @@ public class ApiService {
      public ApiPage list(ApiDTO apiDTO, PageableDTO pageableDTO) {
 
           Api api = GenericConverter.mapper(apiDTO, Api.class);
-          
+
           Example<Api> example = Example.of(api, ExampleMatcher.matching().withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
-          
+
           Pageable pageable = Pageable.setPageable(pageableDTO.getOffset(), pageableDTO.getLimit());
           Page<Api> page = apiRepository.findAll(example, pageable);
-          
+
           ApiPage apiPage = new ApiPage(PageDTO.build(page));
-          
+
           return apiPage;
      }
 
      /**
       * Generates a list of the {@link Api}'s
-      * 
+      *
       * @param 	apiDTO					{@link ApiDTO}
       * @param 	pageableDTO				The pageable DTO
       * @return 						The list of {@link Api}'s
       */
      public List<Api> list(ApiDTO apiDTO) {
-          
+
           Api api = GenericConverter.mapper(apiDTO, Api.class);
-          
+
           Example<Api> example = Example.of(api, ExampleMatcher.matching().withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
-          
+
           List<Api> apis = apiRepository.findAll(example);
-          
+
           return apis;
      }
-     
+
      /**
       * Saves a {@link Api}.
-      * 
+      *
       * @param 	apiDTO					{@link ApiDTO}
       * @return							The saved {@link Api}
       * @throws	BadRequestException		The basepath defined exist
@@ -129,23 +134,24 @@ public class ApiService {
       * @throws     BadRequestException      Basepath can not be empty
       */
      public Api save(ApiDTO apiDTO) {
-          
+
           Api validateApi = apiRepository.findByBasePath(apiDTO.getBasePath());
           HeimdallException.checkThrow(notBlank(validateApi), API_BASEPATH_EXIST);
           HeimdallException.checkThrow(validateBasepath(apiDTO), API_BASEPATH_MALFORMED);
           HeimdallException.checkThrow(isBlank(apiDTO.getBasePath()), API_BASEPATH_EMPTY);
+          HeimdallException.checkThrow(validateInboundsEnvironments(apiDTO.getEnvironments()), API_CANT_ENVIRONMENT_INBOUND_URL_EQUALS);
 
           Api api = GenericConverter.mapperWithMapping(apiDTO, Api.class, new ApiMap());
-          
+
           api = apiRepository.save(api);
-          
+
           amqpRoute.dispatchRoutes();
           return api;
      }
 
      /**
       * Updates a {@link Api} by its ID.
-      *  
+      *
       * @param 	id						The ID of the {@link Api}
       * @param 	apiDTO					{@link ApiDTO}
       * @return							The updated {@link Api}
@@ -158,23 +164,24 @@ public class ApiService {
 
           Api api = apiRepository.findOne(id);
           HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
-          
+
           Api validateApi = apiRepository.findByBasePath(apiDTO.getBasePath());
           HeimdallException.checkThrow(notBlank(validateApi) && validateApi.getId() != api.getId(), API_BASEPATH_EXIST);
           HeimdallException.checkThrow(validateBasepath(apiDTO), API_BASEPATH_MALFORMED);
           HeimdallException.checkThrow(isBlank(apiDTO.getBasePath()), API_BASEPATH_EMPTY);
+          HeimdallException.checkThrow(validateInboundsEnvironments(apiDTO.getEnvironments()), API_CANT_ENVIRONMENT_INBOUND_URL_EQUALS);
 
           api = GenericConverter.mapperWithMapping(apiDTO, api, new ApiMap());
           api = apiRepository.save(api);
-          
+
           amqpRoute.dispatchRoutes();
-          
+
           return api;
      }
-     
+
      /**
       * Deletes a {@link Api} by its ID.
-      * 
+      *
       * @param 	id						The ID of the {@link Api}
       * @throws	NotFoundException		Resource not found
       */
@@ -182,20 +189,38 @@ public class ApiService {
 
           Api api = apiRepository.findOne(id);
           HeimdallException.checkThrow(isBlank(api), GLOBAL_RESOURCE_NOT_FOUND);
-          
+
           apiRepository.delete(api);
           amqpRoute.dispatchRoutes();
      }
 
-     /*
-      * A Api basepath can not have any sort of wild card.
-      */
-     private static boolean validateBasepath(ApiDTO apiDTO) {
-          List<String> basepath = Arrays.asList(
-                    apiDTO.getBasePath()
-                    .split("/")
-                );
-          
-          return basepath.contains("*") || basepath.contains("**");
-     }
+    /*
+     * A Api basepath can not have any sort of wild card.
+     */
+    private static boolean validateBasepath(ApiDTO apiDTO) {
+        List<String> basepath = Arrays.asList(
+                apiDTO.getBasePath()
+                        .split("/")
+        );
+
+        return basepath.contains("*") || basepath.contains("**");
+    }
+
+    /**
+     * Verify in environments if there are equal inbounds
+     *
+     * @param environmentsIds {@link List}<{@link ReferenceIdDTO}>
+     * @return True if exist, false otherwise
+     */
+    private boolean validateInboundsEnvironments(List<ReferenceIdDTO> environmentsIds) {
+
+        List<String> inbounds = environmentsIds.stream()
+                .map(e -> environmentService.find(e.getId()))
+                .filter(Objects::nonNull)
+                .map(Environment::getInboundURL)
+                .filter(e -> e != null && !e.isEmpty())
+                .collect(Collectors.toList());
+
+        return inbounds.stream().anyMatch(inbound -> Collections.frequency(inbounds, inbound) > 1);
+    }
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/ApiService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/ApiService.java
@@ -34,7 +34,6 @@ import br.com.conductor.heimdall.core.exception.HeimdallException;
 import br.com.conductor.heimdall.core.repository.ApiRepository;
 import br.com.conductor.heimdall.core.service.amqp.AMQPRouteService;
 import br.com.conductor.heimdall.core.util.Pageable;
-import br.com.twsoftware.alfred.object.Objeto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;

--- a/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/ApiServiceTest.java
+++ b/heimdall-core/src/test/java/br/com/conductor/heimdall/core/service/ApiServiceTest.java
@@ -1,0 +1,376 @@
+package br.com.conductor.heimdall.core.service;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import br.com.conductor.heimdall.core.dto.ApiDTO;
+import br.com.conductor.heimdall.core.dto.ReferenceIdDTO;
+import br.com.conductor.heimdall.core.entity.Api;
+import br.com.conductor.heimdall.core.entity.Environment;
+import br.com.conductor.heimdall.core.enums.Status;
+import br.com.conductor.heimdall.core.exception.BadRequestException;
+import br.com.conductor.heimdall.core.repository.ApiRepository;
+import br.com.conductor.heimdall.core.service.amqp.AMQPRouteService;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiServiceTest {
+
+
+    @InjectMocks
+    private ApiService apiService;
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private AMQPRouteService amqpRoute;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ApiDTO apiDTO;
+
+    private Api api;
+
+    @Before
+    public void initAttributes() {
+        api = new Api();
+        api.setId(1L);
+        api.setBasePath("/test");
+
+        apiDTO = new ApiDTO();
+        apiDTO.setName("test");
+        apiDTO.setBasePath("/test");
+        apiDTO.setDescription("test");
+        apiDTO.setVersion("1.0.0");
+        apiDTO.setStatus(Status.ACTIVE);
+    }
+
+    @Test
+    public void saveTestWithSuccess() {
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("http://localhost:8081");
+
+        Environment e3 = new Environment();
+        e3.setInboundURL("http://localhost:8082");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api saved = apiService.save(apiDTO);
+
+        assertEquals(saved.getId(), api.getId());
+    }
+
+    @Test
+    public void saveTestWithEnvironmentNull() {
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("http://localhost:8081");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(null);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api saved = apiService.save(apiDTO);
+
+        assertEquals(saved.getId(), api.getId());
+    }
+
+    @Test
+    public void saveTestWithInboundEnvironmentsNull() {
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+
+        Environment e3 = new Environment();
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api saved = apiService.save(apiDTO);
+
+        assertEquals(saved.getId(), api.getId());
+    }
+
+    @Test
+    public void saveTestWithInboundEnvironmentsEmpty() {
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("");
+
+        Environment e3 = new Environment();
+        e3.setInboundURL("");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api saved = apiService.save(apiDTO);
+
+        assertEquals(saved.getId(), api.getId());
+    }
+
+    @Test
+    public void saveTestExpectedException() {
+
+        thrown.expect(BadRequestException.class);
+        thrown.expectMessage("Apis can't have environments with the same inbound url");
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("http://localhost:8081");
+
+        Environment e3 = new Environment();
+        e3.setInboundURL("http://localhost:8081");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api saved = apiService.save(apiDTO);
+    }
+
+    @Test
+    public void updateTestSuccess() {
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("http://localhost:8081");
+
+        Environment e3 = new Environment();
+        e3.setInboundURL("http://localhost:8082");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(apiRepository.findOne(Mockito.anyLong())).thenReturn(api);
+        Mockito.when(apiRepository.findByBasePath(Mockito.anyString())).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api update = apiService.update(1L, apiDTO);
+
+        assertEquals(update.getId(), api.getId());
+    }
+
+    @Test
+    public void updateTestEnvironmentsNull() {
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("http://localhost:8081");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(apiRepository.findOne(Mockito.anyLong())).thenReturn(api);
+        Mockito.when(apiRepository.findByBasePath(Mockito.anyString())).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(null);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api update = apiService.update(1L, apiDTO);
+
+        assertEquals(update.getId(), api.getId());
+    }
+
+    @Test
+    public void updateTestInboundsEnvironmentNull() {
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+
+        Environment e3 = new Environment();
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(apiRepository.findOne(Mockito.anyLong())).thenReturn(api);
+        Mockito.when(apiRepository.findByBasePath(Mockito.anyString())).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api update = apiService.update(1L, apiDTO);
+
+        assertEquals(update.getId(), api.getId());
+    }
+
+    @Test
+    public void updateTestInboundsEnvironmentEmpty() {
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("");
+
+        Environment e3 = new Environment();
+        e3.setInboundURL("");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(apiRepository.findOne(Mockito.anyLong())).thenReturn(api);
+        Mockito.when(apiRepository.findByBasePath(Mockito.anyString())).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api update = apiService.update(1L, apiDTO);
+
+        assertEquals(update.getId(), api.getId());
+    }
+
+    @Test
+    public void updateTestExpectedException() {
+
+        thrown.expect(BadRequestException.class);
+        thrown.expectMessage("Apis can't have environments with the same inbound url");
+
+        Environment e1 = new Environment();
+        e1.setInboundURL("http://localhost:8080");
+
+        Environment e2 = new Environment();
+        e2.setInboundURL("http://localhost:8080");
+
+        Environment e3 = new Environment();
+        e3.setInboundURL("http://localhost:8081");
+
+        Mockito.when(apiRepository.save(Mockito.any(Api.class))).thenReturn(api);
+        Mockito.when(apiRepository.findOne(Mockito.anyLong())).thenReturn(api);
+        Mockito.when(apiRepository.findByBasePath(Mockito.anyString())).thenReturn(api);
+        Mockito.when(environmentService.find(1L)).thenReturn(e1);
+        Mockito.when(environmentService.find(2L)).thenReturn(e2);
+        Mockito.when(environmentService.find(3L)).thenReturn(e3);
+
+
+        List<ReferenceIdDTO> environmentsDTO = new ArrayList<>();
+        environmentsDTO.add(new ReferenceIdDTO(1L));
+        environmentsDTO.add(new ReferenceIdDTO(2L));
+        environmentsDTO.add(new ReferenceIdDTO(3L));
+
+        apiDTO.setEnvironments(environmentsDTO);
+
+        Api update = apiService.update(1L, apiDTO);
+    }
+}

--- a/heimdall-frontend/src/components/apps/AppForm.js
+++ b/heimdall-frontend/src/components/apps/AppForm.js
@@ -145,7 +145,7 @@ class AppForm extends Component {
                         </Col>
                     </Row>
                 </Form>
-                {data.length > 0 &&
+                {data && data.length > 0 &&
                 (
                     <div>
                         <fieldset>


### PR DESCRIPTION
**Describe features**
Restrict adding environments with equal inbound url when create or update any api.