### PR TITLE
Helper mock

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/DBMongoImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/DBMongoImpl.java
@@ -68,7 +68,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DBMongoImpl implements DBMongo {
 
-     Json json = new JsonImpl();
+     private Json json = new JsonImpl();
 
      private String databaseName;
 
@@ -136,19 +136,19 @@ public class DBMongoImpl implements DBMongo {
 
           Query<T> query = this.prepareQuery(criteria, this.datastore());
 
-          List<T> list = Lists.newArrayList();
+          List<T> list;
           Long totalElements = query.count();
           
           page = page == null ? PAGE : page;
           limit = limit == null || limit > LIMIT ? LIMIT : limit;
           
-          if ( page >= 1 &&  limit > 0  && limit <= LIMIT) {
+          if (page >= 1 && limit > 0) {
                list = query.asList(new FindOptions().limit(limit).skip(page * limit));  
           } else {
                list = query.asList(new FindOptions().limit(limit));
           }
 
-          return (Page<T>) buildPage(list, page, limit, totalElements);
+          return buildPage(list, page, limit, totalElements);
      }
 
      @Override
@@ -210,9 +210,7 @@ public class DBMongoImpl implements DBMongo {
      @Override
      public <T> Query<T> getQueryProvider(Object criteria) {
 
-          Query<T> query = (Query<T>) this.prepareQuery(criteria, this.datastore());
-
-          return query;
+          return this.prepareQuery(criteria, this.datastore());
      }
 
      @Override
@@ -220,8 +218,9 @@ public class DBMongoImpl implements DBMongo {
 
           page = page == null ? PAGE : page;
           limit = limit == null || limit > LIMIT ? LIMIT : limit;
-          FindIterable<Document> documents = null;
-          if ((page != null && page > 0) && (limit != null && limit > 0) && (limit <= LIMIT)) {
+          FindIterable<Document> documents;
+
+          if (page > 0 && limit > 0) {
 
                if (Objeto.notBlank(filters)) {
 
@@ -230,7 +229,7 @@ public class DBMongoImpl implements DBMongo {
 
                     documents = collection.find().limit(limit).skip(page * limit);
                }
-          } else if ((page != null && page == 0) && (limit != null && limit > 0) && (limit <= LIMIT)) {
+          } else if (page == 0 && limit > 0) {
 
                if (Objeto.notBlank(filters)) {
 
@@ -239,7 +238,7 @@ public class DBMongoImpl implements DBMongo {
 
                     documents = collection.find(Filters.and(filters)).limit(limit);
                }
-          } else if ((limit != null && limit > 0) && (limit <= LIMIT)) {
+          } else if (limit > 0) {
 
                if (Objeto.notBlank(filters)) {
 
@@ -274,17 +273,13 @@ public class DBMongoImpl implements DBMongo {
      @Override
      public MongoCollection<Document> collection(String name) {
 
-          MongoCollection<Document> collection = database().getCollection(name);
-
-          return collection;
+          return database().getCollection(name);
      }
 
      @Override
      public <T> MongoCollection<Document> collection(Class<T> classType) {
 
-          MongoCollection<Document> collection = database().getCollection(classType.getSimpleName());
-
-          return collection;
+          return database().getCollection(classType.getSimpleName());
      }
 
      private MongoClient createMongoClient() {
@@ -327,22 +322,17 @@ public class DBMongoImpl implements DBMongo {
 
      private MongoDatabase database() {
 
-          MongoDatabase database = createMongoClient().getDatabase(databaseName);
-          return database;
+          return createMongoClient().getDatabase(databaseName);
      }
 
      private <T> Object getValueId(T object) {
 
-          Field id = Arrays.asList(object.getClass().getDeclaredFields()).stream().filter(field -> field.getAnnotation(Id.class) != null).findFirst().get();
-          if (id != null) {
-               id.setAccessible(true);
-               try {
-                    return id.get(object);
-               } catch (IllegalArgumentException e) {
-                    log.error(e.getMessage(), e);
-               } catch (IllegalAccessException e) {
-                    log.error(e.getMessage(), e);
-               }
+          Field id = Arrays.stream(object.getClass().getDeclaredFields()).filter(field -> field.getAnnotation(Id.class) != null).findFirst().get();
+          id.setAccessible(true);
+          try {
+               return id.get(object);
+          } catch (IllegalArgumentException | IllegalAccessException e) {
+               log.error(e.getMessage(), e);
           }
           return null;
      }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
@@ -1,5 +1,5 @@
-package br.com.conductor.heimdall.gateway.filter.helper;
 
+package br.com.conductor.heimdall.gateway.filter.helper;
 
 /*-
  * =========================LICENSE_START==================================
@@ -23,7 +23,6 @@ package br.com.conductor.heimdall.gateway.filter.helper;
  
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.http.entity.ContentType;
 import org.springframework.http.HttpEntity;
@@ -49,17 +48,17 @@ import br.com.twsoftware.alfred.object.Objeto;
  */
 public class HttpImpl implements Http {
 
-     Json json = new JsonImpl();
-     
-     HttpHeaders headers = new HttpHeaders();
+     private Json json = new JsonImpl();
 
-     UriComponentsBuilder uriComponentsBuilder;
+     private HttpHeaders headers = new HttpHeaders();
 
-     HttpEntity<String> requestBody;
-     
-     String body;
+     private UriComponentsBuilder uriComponentsBuilder;
 
-     MultiValueMap<String, String> formData;
+     private HttpEntity<String> requestBody;
+
+     private String body;
+
+     private MultiValueMap<String, String> formData;
 
      public HttpImpl header(String name, String value) {
 
@@ -73,13 +72,10 @@ public class HttpImpl implements Http {
 
      public HttpImpl header(Map<String, String> params) {
 
-          for (Map.Entry<String, String> entry : params.entrySet()) {
-
-               if (Objeto.notBlank(entry.getValue())) {
-                    
-                    headers.add(entry.getKey(), entry.getValue());
-               }
-          }
+          params.forEach((key, value) -> {
+               if (value != null)
+                    headers.add(key, value);
+          });
 
           return this;
      }
@@ -104,12 +100,11 @@ public class HttpImpl implements Http {
      public HttpImpl body(Map<String, Object> params) {
 
           if (headers.containsKey("Content-Type") && headers.get("Content-Type").get(0).equals(ContentType.APPLICATION_FORM_URLENCODED.getMimeType())) {
-               formData = new LinkedMultiValueMap<String, String>();
-               for (Entry<String, Object> entry : params.entrySet()) {
-                    
-                    List<String> values = Lists.newArrayList(entry.getValue().toString());
-                    formData.put(entry.getKey(), values);
-               }               
+               formData = new LinkedMultiValueMap<>();
+               params.forEach((key, value) -> {
+                    List<String> values = Lists.newArrayList(value.toString());
+                    formData.put(key, values);
+               });
           } else {
                
                body = json.parse(params);          
@@ -128,7 +123,7 @@ public class HttpImpl implements Http {
      
      public ApiResponseImpl sendGet() {
           
-          ResponseEntity<String> entity = null;
+          ResponseEntity<String> entity;
           
           if (headers.isEmpty()) {
                
@@ -148,7 +143,7 @@ public class HttpImpl implements Http {
 
      public ApiResponseImpl sendPost() {
 
-          ResponseEntity<String> entity = null;
+          ResponseEntity<String> entity;
           if (headers.isEmpty()) {
                
                requestBody = new HttpEntity<>(body);
@@ -157,7 +152,7 @@ public class HttpImpl implements Http {
                
                if (Objeto.notBlank(formData)) {
                     
-                    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(formData, headers);
+                    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(formData, headers);
                     entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.POST, request, String.class);
                } else {
                     
@@ -179,7 +174,7 @@ public class HttpImpl implements Http {
 
      public ApiResponseImpl sendPut() {
 
-          ResponseEntity<String> entity = null;
+          ResponseEntity<String> entity;
           if (headers.isEmpty()) {
                
                requestBody = new HttpEntity<>(body);
@@ -188,7 +183,7 @@ public class HttpImpl implements Http {
                
                if (Objeto.notBlank(formData)) {
                     
-                    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(formData, headers);
+                    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(formData, headers);
                     entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.PUT, request, String.class);
                } else {
                     
@@ -217,9 +212,7 @@ public class HttpImpl implements Http {
 
      private RestTemplate rest() {
 
-          RestTemplate restTemplate = new RestTemplate();
-
-          return restTemplate;
+          return new RestTemplate();
      }    
 
 }

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -46,6 +46,16 @@
 			<artifactId>modelmapper</artifactId>
 			<version>0.7.8</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.7.1</version>
+			<scope>provided</scope>
+		</dependency>
 		
 	</dependencies>
 

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/ApiResponseMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/ApiResponseMockImpl.java
@@ -1,0 +1,41 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.ApiResponse;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+@Data
+class ApiResponseMockImpl implements ApiResponse {
+    private String body;
+
+    private Map<String, String> headers;
+
+    private Integer status;
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/CallMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/CallMockImpl.java
@@ -1,0 +1,58 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.*;
+import br.com.conductor.heimdall.middleware.util.helpermock.call.*;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class CallMockImpl implements Call {
+
+    @Override
+    public Request request() {
+        return new RequestMock();
+    }
+
+    @Override
+    public Response response() {
+        return new ResponseMock();
+    }
+
+    @Override
+    public Trace trace() {
+        return new TraceMock();
+    }
+
+    @Override
+    public Environment environment() {
+        return new EnvironmentMock();
+    }
+
+    @Override
+    public Info info() {
+        return new InfoMock();
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/DBMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/DBMockImpl.java
@@ -1,0 +1,333 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.DBMongo;
+import br.com.conductor.heimdall.middleware.spec.Helper;
+import br.com.conductor.heimdall.middleware.spec.Json;
+import br.com.conductor.heimdall.middleware.util.Page;
+import br.com.twsoftware.alfred.object.Objeto;
+import com.google.common.collect.Lists;
+import com.mongodb.MongoClient;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.mockito.Mockito;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.query.FindOptions;
+import org.mongodb.morphia.query.Query;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class DBMockImpl implements DBMongo {
+
+    private Json json = new JsonMockImpl();
+
+    private String databaseName;
+
+    private final static Integer PAGE = 0;
+
+    private final static Integer LIMIT = 100;
+
+    private Helper helper = new HelperMock();
+
+    DBMockImpl(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+    @Override
+    public <T> T save(T object) {
+
+        try {
+            this.datastore().save(object);
+            return object;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public <T> T update(T object) {
+
+        return save(object);
+    }
+
+    @Override
+    public <T> Boolean delete(T object) {
+
+        this.datastore().delete(object);
+        return true;
+    }
+
+    @Override
+    public <T> T findOne(T object) {
+
+        Object idMongo = getValueId(object);
+        return (T) this.datastore().get(object.getClass(), idMongo);
+    }
+
+    @Override
+    public <T> List<T> findAll(Class<T> classType) {
+
+        return datastore().createQuery(classType).asList();
+    }
+
+    @Override
+    public <T> Page<T> find(Object criteria, Integer page, Integer limit) {
+
+        Query<T> query = this.prepareQuery(criteria, this.datastore());
+
+        List<T> list;
+        Long totalElements = query.count();
+
+        page = page == null ? PAGE : page;
+        limit = limit == null || limit > LIMIT ? LIMIT : limit;
+
+        if (page >= 1 && limit > 0) {
+            list = query.asList(new FindOptions().limit(limit).skip(page * limit));
+        } else {
+            list = query.asList(new FindOptions().limit(limit));
+        }
+
+        return buildPage(list, page, limit, totalElements);
+    }
+
+    @Override
+    public <T> Page<T> buildPage(List<T> list, Integer page, Integer limit, Long totalElements) {
+
+        Page<T> pageResponse = new Page<>();
+
+        pageResponse.number = page;
+        pageResponse.totalPages = new BigDecimal(totalElements).divide(new BigDecimal(limit), BigDecimal.ROUND_UP, 0).intValue();
+        pageResponse.numberOfElements = limit;
+        pageResponse.totalElements = totalElements;
+        pageResponse.hasPreviousPage = page > 0;
+        pageResponse.hasNextPage = page < (pageResponse.totalPages - 1);
+        pageResponse.hasContent = Objeto.notBlank(list);
+        pageResponse.first = page == 0;
+        pageResponse.last = page == (pageResponse.totalPages - 1);
+        pageResponse.nextPage = page == (pageResponse.totalPages - 1) ? page : page + 1;
+        pageResponse.previousPage = page == 0 ? 0 : page - 1;
+        pageResponse.content = list;
+
+        return pageResponse;
+    }
+
+    @Override
+    public <T> void insertMany(MongoCollection<Document> collection, List<T> objects) {
+
+        try {
+
+            List<Document> ts = Lists.newArrayList();
+            for (T t : objects) {
+
+                ts.add(Document.parse(json.parse(t)));
+            }
+            collection.insertMany(ts);
+        } catch (Exception ignored) {
+        } finally {
+
+            createMongoClient().close();
+        }
+    }
+
+    @Override
+    public <T> void insertOne(MongoCollection<Document> collection, T object) {
+
+        try {
+
+            Document document = Document.parse(json.parse(object));
+            collection.insertOne(document);
+        } catch (Exception ignored) {
+        } finally {
+
+            createMongoClient().close();
+        }
+    }
+
+    @Override
+    public <T> Query<T> getQueryProvider(Object criteria) {
+
+        return (Query<T>) this.prepareQuery(criteria, this.datastore());
+    }
+
+    @Override
+    public <T> Page<T> find(MongoCollection<Document> collection, Class<T> classType, Bson filters, Integer page, Integer limit) {
+
+        page = page == null ? PAGE : page;
+        limit = limit == null || limit > LIMIT ? LIMIT : limit;
+        FindIterable<Document> documents;
+
+        if (page > 0 && limit > 0) {
+
+            if (Objeto.notBlank(filters)) {
+
+                documents = collection.find(Filters.and(filters)).limit(limit).skip(page * limit);
+            } else {
+
+                documents = collection.find().limit(limit).skip(page * limit);
+            }
+        } else if (page == 0 && limit > 0) {
+
+            if (Objeto.notBlank(filters)) {
+
+                documents = collection.find().limit(limit);
+            } else {
+
+                documents = collection.find(Filters.and(filters)).limit(limit);
+            }
+        } else if (limit > 0) {
+
+            if (Objeto.notBlank(filters)) {
+
+                documents = collection.find().limit(limit);
+            } else {
+
+                documents = collection.find(Filters.and(filters)).limit(limit);
+            }
+        } else {
+
+            if (Objeto.notBlank(filters)) {
+
+                documents = collection.find(Filters.and(filters)).limit(LIMIT);
+            } else {
+
+                documents = collection.find().limit(LIMIT);
+            }
+        }
+
+        Long totalElements = collection.count();
+
+        List<T> list = Lists.newArrayList();
+        for (Document document : documents) {
+
+            T parse = helper.json().parse(document.toJson(), classType);
+            list.add(parse);
+        }
+
+        return buildPage(list, page, limit, totalElements);
+    }
+
+    @Override
+    public MongoCollection<Document> collection(String name) {
+
+        return database().getCollection(name);
+    }
+
+    @Override
+    public <T> MongoCollection<Document> collection(Class<T> classType) {
+
+        return database().getCollection(classType.getSimpleName());
+    }
+
+    @Override
+    public <T> T merge(T object) {
+
+        try {
+            Datastore ds = this.datastore();
+            ds.merge(object);
+            return findOne(object);
+        } catch (Exception e) {
+            return null;
+        }
+
+    }
+
+    /*
+     * Private helper methods
+     */
+    private MongoClient createMongoClient() {
+
+        return Mockito.mock(MongoClient.class);
+    }
+
+    private Datastore datastore() {
+
+        Morphia morphia = new Morphia();
+
+        return morphia.createDatastore(createMongoClient(), this.databaseName);
+    }
+
+    private MongoDatabase database() {
+
+        return createMongoClient().getDatabase(databaseName);
+    }
+
+    private <T> Object getValueId(T object) {
+
+        Field id = Arrays.stream(object.getClass().getDeclaredFields()).filter(field -> field.getAnnotation(Id.class) != null).findFirst().get();
+        id.setAccessible(true);
+        try {
+            return id.get(object);
+        } catch (IllegalArgumentException | IllegalAccessException ignored) { }
+        return null;
+    }
+
+    private <T> Query<T> prepareQuery(Object criteria, Datastore dataStore) {
+
+        Query<T> query = (Query<T>) dataStore.createQuery(criteria.getClass());
+
+        List<Field> fields = this.getAllModelFields(criteria.getClass());
+        for (Field field : fields) {
+            field.setAccessible(true);
+            Object value = null;
+            try {
+                value = field.get(criteria);
+            } catch (IllegalArgumentException | IllegalAccessException ignored) {}
+
+            if (value != null) {
+                query.criteria(field.getName()).equal(value);
+            }
+        }
+
+        return query;
+    }
+
+    private <T> List<Field> getAllModelFields(Class<T> aClass) {
+
+        List<Field> results = new ArrayList<>();
+
+        List<Field> fields = Arrays.asList(aClass.getDeclaredFields());
+        fields.forEach(field -> {
+
+            if (!"serialVersionUID".equals(field.getName()))
+                results.add(field);
+        });
+
+        return results;
+    }
+
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HelperMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HelperMock.java
@@ -49,7 +49,6 @@ public class HelperMock implements Helper {
 
     @Override
     public DB db(String databaseName) {
-
         return new DBMockImpl(databaseName);
     }
 

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HelperMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HelperMock.java
@@ -1,0 +1,75 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Helper;
+import br.com.conductor.heimdall.middleware.spec.ApiResponse;
+import br.com.conductor.heimdall.middleware.spec.Call;
+import br.com.conductor.heimdall.middleware.spec.DB;
+import br.com.conductor.heimdall.middleware.spec.DBMongo;
+import br.com.conductor.heimdall.middleware.spec.Http;
+import br.com.conductor.heimdall.middleware.spec.Json;
+import br.com.conductor.heimdall.middleware.spec.Xml;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class HelperMock implements Helper {
+
+    @Override
+    public ApiResponse apiResponse() {
+        return new ApiResponseMockImpl();
+    }
+
+    @Override
+    public Call call() {
+        return new CallMockImpl();
+    }
+
+    @Override
+    public DB db(String databaseName) {
+
+        return new DBMockImpl(databaseName);
+    }
+
+    @Override
+    public DBMongo dbMongo(String databaseName) {
+        return (DBMongo) db(databaseName);
+    }
+
+    @Override
+    public Http http() {
+        return new HttpMockImpl();
+    }
+
+    @Override
+    public Json json() {
+        return new JsonMockImpl();
+    }
+
+    @Override
+    public Xml xml() {
+        return new XmlMockImpl();
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
@@ -25,6 +25,7 @@ import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Http;
 import br.com.conductor.heimdall.middleware.spec.Json;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -34,12 +35,17 @@ import java.util.Map;
  */
 public class HttpMockImpl implements Http {
 
-    private Json json = new JsonMockImpl();
+    private Json json;
     private Map<String, String> headers;
     private Map<String, String> queryParams;
     private String url;
     private String body;
 
+    public HttpMockImpl() {
+        this.json = new JsonMockImpl();
+        this.headers = new HashMap<>();
+        this.queryParams = new HashMap<>();
+    }
 
     @Override
     public Http header(String name, String value) {
@@ -91,7 +97,7 @@ public class HttpMockImpl implements Http {
         ApiResponse response = new ApiResponseMockImpl();
 
         response.setHeaders(headers);
-        response.setBody(body);
+        response.setBody("{ \"response\" : \"response body\"");
         response.setStatus(200);
 
         return response;

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
@@ -1,0 +1,84 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.ApiResponse;
+import br.com.conductor.heimdall.middleware.spec.Http;
+
+import java.util.Map;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class HttpMockImpl implements Http {
+    @Override
+    public Http header(String name, String value) {
+        return null;
+    }
+
+    @Override
+    public Http header(Map<String, String> params) {
+        return null;
+    }
+
+    @Override
+    public Http url(String url) {
+        return null;
+    }
+
+    @Override
+    public Http queryParam(String name, String value) {
+        return null;
+    }
+
+    @Override
+    public Http body(Map<String, Object> params) {
+        return null;
+    }
+
+    @Override
+    public Http body(String params) {
+        return null;
+    }
+
+    @Override
+    public ApiResponse sendGet() {
+        return null;
+    }
+
+    @Override
+    public ApiResponse sendPost() {
+        return null;
+    }
+
+    @Override
+    public ApiResponse sendPut() {
+        return null;
+    }
+
+    @Override
+    public ApiResponse sendDelete() {
+        return null;
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
@@ -23,6 +23,7 @@ package br.com.conductor.heimdall.middleware.util.helpermock;
 
 import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Http;
+import br.com.conductor.heimdall.middleware.spec.Json;
 
 import java.util.Map;
 
@@ -32,53 +33,82 @@ import java.util.Map;
  * @author Marcelo Aguiar
  */
 public class HttpMockImpl implements Http {
+
+    private Json json = new JsonMockImpl();
+    private Map<String, String> headers;
+    private Map<String, String> queryParams;
+    private String url;
+    private String body;
+
+
     @Override
     public Http header(String name, String value) {
-        return null;
+
+        this.headers.put(name, value);
+
+        return this;
     }
 
     @Override
     public Http header(Map<String, String> params) {
-        return null;
+
+        params.forEach((k, v) -> {
+            if (v != null) {
+                this.headers.put(k, v);
+            }
+        });
+
+        return this;
     }
 
     @Override
     public Http url(String url) {
-        return null;
+        this.url = url;
+        return this;
     }
 
     @Override
     public Http queryParam(String name, String value) {
-        return null;
+        this.queryParams.put(name, value);
+        return this;
     }
 
     @Override
     public Http body(Map<String, Object> params) {
-        return null;
+        this.body = json.parse(params);
+        return this;
     }
 
     @Override
     public Http body(String params) {
-        return null;
+        this.body = json.parse(params);
+        return this;
     }
 
     @Override
     public ApiResponse sendGet() {
-        return null;
+
+        ApiResponse response = new ApiResponseMockImpl();
+
+        response.setHeaders(headers);
+        response.setBody(body);
+        response.setStatus(200);
+
+        return response;
     }
 
     @Override
     public ApiResponse sendPost() {
-        return null;
+        return this.sendGet();
     }
 
     @Override
     public ApiResponse sendPut() {
-        return null;
+        return this.sendGet();
     }
 
     @Override
     public ApiResponse sendDelete() {
-        return null;
+        return this.sendGet();
     }
 }

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/JsonMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/JsonMockImpl.java
@@ -1,0 +1,139 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Json;
+import br.com.twsoftware.alfred.object.Objeto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Map;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class JsonMockImpl implements Json {
+
+    public String parse(Map<String, Object> body) {
+
+        try {
+            return mapper().writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+
+            return null;
+        }
+    }
+
+    public String parse(String string) {
+
+        try {
+
+            JSONObject jsonObject = new JSONObject(string);
+
+            return jsonObject.toString();
+        } catch (JSONException e) {
+            try {
+                JSONArray array = new JSONArray(string);
+                return array.toString();
+            } catch (JSONException ex1) {
+                if (Objeto.notBlank(string))
+                    return string;
+            }
+        }
+
+        return null;
+    }
+
+    public <T> String parse(T object) {
+
+        try {
+
+            return mapper().writeValueAsString(object);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public <T> T parse(String json, Class<?> classType) {
+
+        try {
+            mapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            @SuppressWarnings("unchecked")
+            T obj = (T) mapper().readValue(json, classType);
+            return obj;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public <T> Map<String, Object> parseToMap(T object) {
+
+        try {
+            mapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            ObjectMapper mapper = mapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            String jsonInString = mapper.writeValueAsString(object);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = mapper.readValue(jsonInString, Map.class);
+            return map;
+        } catch (Exception e) {
+
+            return null;
+        }
+    }
+
+    public boolean isJson(String string) {
+
+        boolean valid = false;
+        try {
+            JSONObject jsonObject = new JSONObject(string);
+
+            if (Objeto.notBlank(jsonObject))
+                valid = true;
+        } catch (JSONException e) {
+
+            try {
+                new JSONArray(string);
+                valid = true;
+            } catch (JSONException ignored) { }
+        }
+
+        return valid;
+    }
+
+    private ObjectMapper mapper() {
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        return mapper;
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/JsonMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/JsonMockImpl.java
@@ -22,7 +22,6 @@ package br.com.conductor.heimdall.middleware.util.helpermock;
  */
 
 import br.com.conductor.heimdall.middleware.spec.Json;
-import br.com.twsoftware.alfred.object.Objeto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -63,7 +62,7 @@ public class JsonMockImpl implements Json {
                 JSONArray array = new JSONArray(string);
                 return array.toString();
             } catch (JSONException ex1) {
-                if (Objeto.notBlank(string))
+                if (!string.isEmpty())
                     return string;
             }
         }
@@ -115,8 +114,7 @@ public class JsonMockImpl implements Json {
         try {
             JSONObject jsonObject = new JSONObject(string);
 
-            if (Objeto.notBlank(jsonObject))
-                valid = true;
+            valid = true;
         } catch (JSONException e) {
 
             try {

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/XmlMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/XmlMockImpl.java
@@ -1,0 +1,69 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Xml;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import java.io.IOException;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class XmlMockImpl implements Xml {
+
+    @Override
+    public <T> String parse(T object) {
+
+        try {
+            return mapper().writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T parse(String xml, Class<?> classType) {
+
+        try {
+            return (T) mapper().readValue(xml, classType);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private ObjectMapper mapper() {
+
+        ObjectMapper mapper = new XmlMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        return mapper;
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/EnvironmentMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/EnvironmentMock.java
@@ -1,0 +1,62 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Environment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class EnvironmentMock implements Environment {
+
+    private Map<String, String> currentVariables;
+
+    public EnvironmentMock() {
+        this.currentVariables = new HashMap<>();
+    }
+
+    @Override
+    public Map<String, String> getVariables() {
+
+        return currentVariables;
+    }
+
+    @Override
+    public String getVariable(String key) {
+
+        return currentVariables.get(key);
+    }
+
+    /**
+     * Use this method to set the mock environment variables
+     *
+     * @param currentVariables Environment variables Map
+     */
+    public void setCurrentVariables(Map<String, String> currentVariables) {
+        this.currentVariables = currentVariables;
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/HeaderMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/HeaderMock.java
@@ -1,0 +1,73 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Header;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class HeaderMock implements Header {
+
+    private Map<String, String> headers;
+
+    HeaderMock() {
+        this.headers = new HashMap<>();
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        return this.headers;
+    }
+
+    @Override
+    public String get(String name) {
+        return this.headers.get(name);
+    }
+
+    @Override
+    public void set(String name, String value) {
+        this.add(name, value);
+    }
+
+    @Override
+    public void add(String name, String value) {
+        this.headers.put(name, value);
+    }
+
+    @Override
+    public void remove(String name) {
+        this.headers.remove(name);
+    }
+
+    @Override
+    public String getMethod() {
+        return "";
+    }
+
+
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/InfoMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/InfoMock.java
@@ -1,0 +1,228 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Info;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class InfoMock implements Info {
+
+    private String app;
+    private String apiName;
+    private Long apiId;
+    private String appDeveloper;
+    private String method;
+    private String clientId;
+    private String accessToken;
+    private String pattern;
+    private Long operationId;
+    private String profile;
+    private Long resourceId;
+    private String url;
+    private String requestURI;
+
+    @Override
+    public String appName() {
+        return this.app;
+    }
+
+    @Override
+    public String apiName() {
+        return this.apiName;
+    }
+
+    @Override
+    public Long apiId() {
+        return this.apiId;
+    }
+
+    @Override
+    public String developer() {
+        return this.appDeveloper;
+    }
+
+    @Override
+    public String method() {
+        return this.method;
+    }
+
+    @Override
+    public String clientId() {
+        return this.clientId;
+    }
+
+    @Override
+    public String accessToken() {
+        return this.accessToken;
+    }
+
+    @Override
+    public String pattern() {
+        return this.pattern;
+    }
+
+    @Override
+    public Long operationId() {
+        return this.operationId;
+    }
+
+    @Override
+    public String profile() {
+        return this.profile;
+    }
+
+    @Override
+    public Long resourceId() {
+        return this.resourceId;
+    }
+
+    @Override
+    public String url() {
+        return this.url;
+    }
+
+    @Override
+    public String requestURI() {
+        return this.requestURI;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param app app
+     */
+    public void setApp(String app) {
+        this.app = app;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param apiName api name
+     */
+    public void setApiName(String apiName) {
+        this.apiName = apiName;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param apiId api id
+     */
+    public void setApiId(Long apiId) {
+        this.apiId = apiId;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param appDeveloper app Developer
+     */
+    public void setAppDeveloper(String appDeveloper) {
+        this.appDeveloper = appDeveloper;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param method method
+     */
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param clientId clientId
+     */
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param accessToken access Token
+     */
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param pattern pattern
+     */
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param operationId operation id
+     */
+    public void setOperationId(Long operationId) {
+        this.operationId = operationId;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param profile profile
+     */
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param resourceId resource id
+     */
+    public void setResourceId(Long resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param url url
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param requestURI request URI
+     */
+    public void setRequestURI(String requestURI) {
+        this.requestURI = requestURI;
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/QueryMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/QueryMock.java
@@ -1,0 +1,66 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Query;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class QueryMock implements Query {
+
+    private Map<String, String> queries;
+
+    QueryMock() {
+        this.queries = new HashMap<>();
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        return this.queries;
+    }
+
+    @Override
+    public String get(String name) {
+        return this.queries.get(name);
+    }
+
+    @Override
+    public void set(String name, String value) {
+        this.add(name, value);
+    }
+
+    @Override
+    public void add(String name, String value) {
+        this.queries.put(name, value);
+    }
+
+    @Override
+    public void remove(String name) {
+        this.queries.remove(name);
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/RequestMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/RequestMock.java
@@ -34,6 +34,7 @@ public class RequestMock implements Request {
 
     private String body;
     private String url;
+    private String appName;
 
     @Override
     public Header header() {
@@ -67,19 +68,48 @@ public class RequestMock implements Request {
 
     @Override
     public String pathParam(String name) {
-        // TODO
-        return null;
+
+        name = "{"+ name +"}";
+
+        String patternText = "";
+        String requestURIText = "";
+        String separator = "/";
+        String[] a = patternText.split(separator);
+        String[] b = requestURIText.split(separator);
+
+        String value = null;
+
+        for (int i = 0; i < a.length; i++) {
+
+            if (a[i].equals(name) && !a[i].equals(b[i])) {
+
+                value = b[i];
+                break;
+            }
+        }
+
+        return value;
+
+
     }
 
     @Override
     public String getAppName() {
-        // TODO
-        return null;
+        return this.appName;
     }
 
     @Override
     public void setSendResponse(boolean value) {
-        // TODO
+        boolean sendResponse = value;
+    }
+
+    /**
+     * Set method designed for mock purposes
+     *
+     * @param appName app name
+     */
+    public void setAppName(String appName) {
+        this.appName = appName;
     }
 }
 

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/RequestMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/RequestMock.java
@@ -1,0 +1,85 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Header;
+import br.com.conductor.heimdall.middleware.spec.Query;
+import br.com.conductor.heimdall.middleware.spec.Request;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class RequestMock implements Request {
+
+    private String body;
+    private String url;
+
+    @Override
+    public Header header() {
+        return new HeaderMock();
+    }
+
+    @Override
+    public Query query() {
+        return new QueryMock();
+    }
+
+    @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    @Override
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    @Override
+    public void setUrl(String routeUrl) {
+        this.url = routeUrl;
+    }
+
+    @Override
+    public String getUrl() {
+        return this.url;
+    }
+
+    @Override
+    public String pathParam(String name) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public String getAppName() {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public void setSendResponse(boolean value) {
+        // TODO
+    }
+}
+

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/ResponseMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/ResponseMock.java
@@ -1,0 +1,68 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.Header;
+import br.com.conductor.heimdall.middleware.spec.Response;
+
+import java.util.Arrays;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class ResponseMock implements Response {
+
+    private Integer status;
+    private String body;
+
+    @Override
+    public Header header() {
+        return new HeaderMock();
+    }
+
+    @Override
+    public Integer getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    @Override
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    @Override
+    public void setBody(byte[] body) {
+        this.body = Arrays.toString(body);
+    }
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/StackTraceMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/StackTraceMock.java
@@ -1,0 +1,45 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.StackTrace;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class StackTraceMock implements StackTrace {
+
+    public String clazz;
+
+    public String message;
+
+    public String stack;
+
+}

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/TraceMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/TraceMock.java
@@ -1,0 +1,58 @@
+
+package br.com.conductor.heimdall.middleware.util.helpermock.call;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-middleware-spec
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.middleware.spec.StackTrace;
+import br.com.conductor.heimdall.middleware.spec.Trace;
+
+/**
+ * Mock class created to help unit test the root request class of a middleware.
+ *
+ * @author Marcelo Aguiar
+ */
+public class TraceMock implements Trace {
+
+    private String trace;
+    private StackTrace stackTrace;
+
+    @Override
+    public void addStackTrace(String clazz, String message, String stack) {
+
+        this.stackTrace = new StackTraceMock(clazz, message, stack);
+    }
+
+    @Override
+    public StackTrace getStackTrace() {
+        return this.stackTrace;
+    }
+
+    @Override
+    public void addTrace(String trace) {
+        this.trace = trace;
+    }
+
+    @Override
+    public void addTrace(String trace, Object object) {
+        this.trace = trace;
+    }
+
+}


### PR DESCRIPTION
1. Changes in `heimdall-middleware-spec` 
    * Created a Mock implementation for the Helper class used by the middlewares to provide an easier way to unit test the middleware.run() method. With this pull request the middleware developer can use a Mock framework like Mockito with ease.

2. Changes in `heimdall-gateway` 
    * `DBMongoImpl` -  removed redundant checks
    * `HttpImpl` - refactored to improve readability