### PR TITLE
Traces logging /manager/**

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/TraceConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/TraceConfiguration.java
@@ -82,7 +82,7 @@ public class TraceConfiguration {
 
 				trace = TraceContextHolder.getInstance().init(prop.getTrace().isPrintAllTrace(), profile, request, prop.getMongo().getEnabled());
 				if (shouldDisableTrace(request)) {
-					TraceContextHolder.getInstance().disablePrint();
+					trace.setShouldPrint(false);
 				}
 
 				if ("OPTIONS".equalsIgnoreCase(((HttpServletRequest) request).getMethod())) {
@@ -102,14 +102,14 @@ public class TraceConfiguration {
 				log.error("Error {} during request {} exception {}", e.getMessage(), ((HttpServletRequest) request).getRequestURL(), e);
 			} finally {
 
-				if (TraceContextHolder.getInstance().shouldWrite()) {
-
-					if (trace != null) {
+				if (trace != null) {
+					if (trace.isShouldPrint()) {
 						trace.write(response);
+					} else {
+						TraceContextHolder.getInstance().clearActual();
 					}
-				} else {
-					TraceContextHolder.getInstance().clearActual();
 				}
+
 				TraceContextHolder.getInstance().unset();
 			}
 		}
@@ -142,13 +142,13 @@ public class TraceConfiguration {
 	@Bean
 	public FilterRegistrationBean filterRegistrationBean() {
 
-		FilterRegistrationBean filtroRestAuth = new FilterRegistrationBean();
-		filtroRestAuth.setFilter(new TraceFilter());
-		filtroRestAuth.addUrlPatterns("/*");
-		filtroRestAuth.setOrder(Ordered.HIGHEST_PRECEDENCE);
-		filtroRestAuth.setName("traceFilter");
+		FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean();
+		filterRegistrationBean.setFilter(new TraceFilter());
+		filterRegistrationBean.addUrlPatterns("/*");
+		filterRegistrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		filterRegistrationBean.setName("traceFilter");
 
-		return filtroRestAuth;
+		return filterRegistrationBean;
 	}
 
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
@@ -117,6 +117,9 @@ public class Trace {
      private boolean printAllTrace;
      @JsonIgnore
      private boolean printMongo;
+
+     @JsonIgnore
+     private boolean shouldPrint;
      
      public Trace() {
     	 
@@ -131,6 +134,7 @@ public class Trace {
       */
      public Trace(boolean printAllTrace, String profile, ServletRequest servletRequest, boolean printMongo){
 
+          this.shouldPrint = true;
           this.profile = profile;
           this.printAllTrace = printAllTrace;
           this.printMongo = printMongo;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/TraceContextHolder.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/TraceContextHolder.java
@@ -33,7 +33,8 @@ import lombok.extern.slf4j.Slf4j;
  *
  * @author Thiago Sampaio
  * @author Filipe Germano
- * @author Fabio Cicupira
+ * @author Fabio Sicupira
+ * @author Marcelo Aguiar Rodrigues
  *
  */
 @Slf4j
@@ -42,13 +43,13 @@ public class TraceContextHolder {
      private static final ThreadLocal<String> contextHolder = new ThreadLocal<>();
 
      private static final ConcurrentHashMap<String, Trace> traceMap = new ConcurrentHashMap<>();
-     
-     private boolean shouldPrint;
+
+     private static final ThreadLocal<Boolean> shouldPrint = new ThreadLocal<>();
 
      /**
       * Implementation of the Initialization-on-demand holder idiom.
       * 
-      * @author Marcelo Rodrigues
+      * @author Marcelo Aguiar Rodrigues
       * @see <a href="http://literatejava.com/jvm/fastest-threadsafe-singleton-jvm/">Fastest Thread-safe Singleton in Java</a>
       * 
       */
@@ -75,7 +76,7 @@ public class TraceContextHolder {
       * @return					{@link Trace}
       */
      public Trace init(boolean printAllTrace, String profile, ServletRequest request, boolean printMongo) {
-          this.shouldPrint = true;
+          shouldPrint.set(true);
           String uuid = UUID.randomUUID().toString();
           contextHolder.set(uuid);
           traceMap.put(uuid, new Trace(printAllTrace, profile, request, printMongo));
@@ -89,7 +90,7 @@ public class TraceContextHolder {
       * Disables the printing.
       */
      public void disablePrint() {
-          this.shouldPrint = false;
+          shouldPrint.set(false);
      }
      
      /**
@@ -97,8 +98,8 @@ public class TraceContextHolder {
       * 
       * @return		boolean should write
       */
-     public boolean shouldWrite() {
-          return this.shouldPrint;
+     public Boolean shouldWrite() {
+          return shouldPrint.get();
      }
      
      /**

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/TraceContextHolder.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/TraceContextHolder.java
@@ -44,8 +44,6 @@ public class TraceContextHolder {
 
      private static final ConcurrentHashMap<String, Trace> traceMap = new ConcurrentHashMap<>();
 
-     private static final ThreadLocal<Boolean> shouldPrint = new ThreadLocal<>();
-
      /**
       * Implementation of the Initialization-on-demand holder idiom.
       * 
@@ -76,7 +74,6 @@ public class TraceContextHolder {
       * @return					{@link Trace}
       */
      public Trace init(boolean printAllTrace, String profile, ServletRequest request, boolean printMongo) {
-          shouldPrint.set(true);
           String uuid = UUID.randomUUID().toString();
           contextHolder.set(uuid);
           traceMap.put(uuid, new Trace(printAllTrace, profile, request, printMongo));
@@ -85,23 +82,7 @@ public class TraceContextHolder {
           return getActualTrace();
 
      }
-     
-     /**
-      * Disables the printing.
-      */
-     public void disablePrint() {
-          shouldPrint.set(false);
-     }
-     
-     /**
-      * Returns boolean that indicates if is safe to write.
-      * 
-      * @return		boolean should write
-      */
-     public Boolean shouldWrite() {
-          return shouldPrint.get();
-     }
-     
+
      /**
       * Returns the actual {@link Trace}.
       * 


### PR DESCRIPTION
**Bug Fix**

Calls made to the health check (/manager/health) were showing up in the logs.
This behaviour happens because the `shouldPrint` variable is not thread safe.

To fix that the controller variable `shoudPrint` was moved to the `Trace` class as it is a instance variable.