### PR TITLE
Trace view tooltip with wrong title

### DIFF
--- a/heimdall-frontend/src/components/traces/ListTraces.js
+++ b/heimdall-frontend/src/components/traces/ListTraces.js
@@ -29,7 +29,7 @@ class ListTraces extends Component {
                         key="action"
                         render={(text, record) => (
                             <span>
-                                <Tooltip title="Edit">
+                                <Tooltip title="View">
                                     <Link to={"/traces/" + record.id}><Button type="primary" icon="search"/></Link>
                                 </Tooltip>
                             </span>


### PR DESCRIPTION
**Bug fix**

In the Trace page the button to show more details has a tooltip with the label "Edit" when it should be "View".