### PR TITLE
Environment removal bugfix

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/EnvironmentService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/EnvironmentService.java
@@ -177,7 +177,7 @@ public class EnvironmentService {
         HeimdallException.checkThrow(isBlank(environment), GLOBAL_RESOURCE_NOT_FOUND);
 
         Integer totalEnvironmentsAttached = environmentRepository.findApisWithEnvironment(id);
-        HeimdallException.checkThrow(totalEnvironmentsAttached == 1, ENVIRONMENT_ATTACHED_TO_API);
+        HeimdallException.checkThrow(totalEnvironmentsAttached > 0, ENVIRONMENT_ATTACHED_TO_API);
 
 
         environmentRepository.delete(environment);


### PR DESCRIPTION
**Environments can be attached to more then one API**

The verification was limited to check for one api, that caused a bug when the environment had more than one api attached.