### PR TITLE
Properly delete resources with operations and interceptors

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/InterceptorRepository.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/InterceptorRepository.java
@@ -37,60 +37,59 @@ import br.com.conductor.heimdall.core.enums.TypeInterceptor;
  *
  * @author Filipe Germano
  * @author Marcelo Aguiar Rodrigues
- *
  */
 public interface InterceptorRepository extends JpaRepository<Interceptor, Long> {
 
-	 /**
-	  * Finds a List of Interceptors by Interceptor type and {@link Plan} Id.
-	  *
-	  * @param  type			The type of Interceptor
-	  * @param  planId			The Plan Id.
-	  * @return					The List of Interceptor associated
-	  */
-     List<Interceptor> findByTypeAndPlanId(TypeInterceptor type, Long planId);
+    /**
+     * Finds a List of Interceptors by Interceptor type and {@link Plan} Id.
+     *
+     * @param type   The type of Interceptor
+     * @param planId The Plan Id.
+     * @return The List of Interceptor associated
+     */
+    List<Interceptor> findByTypeAndPlanId(TypeInterceptor type, Long planId);
 
-     /**
-      * Finds a List of Interceptors by Interceptor type and {@link Resource} Id.
-      *
-      * @param  type			The type of Interceptor
-	  * @param  resourceId		The Resource Id
-      * @return					The List of Interceptor associated
-	  */
-     List<Interceptor> findByTypeAndResourceId(TypeInterceptor type, Long resourceId);
+    /**
+     * Finds a List of Interceptors by Interceptor type and {@link Resource} Id.
+     *
+     * @param type       The type of Interceptor
+     * @param resourceId The Resource Id
+     * @return The List of Interceptor associated
+     */
+    List<Interceptor> findByTypeAndResourceId(TypeInterceptor type, Long resourceId);
 
-     /**
-      * Finds a List of Interceptors by Interceptor type and {@link Operation} Id.
-      *
-      * @param  type			The type of Interceptor
-	  * @param  operationId		The Operation Id
-      * @return					The List of Interceptor associated
-	  */
-     List<Interceptor> findByTypeAndOperationId(TypeInterceptor type, Long operationId);
+    /**
+     * Finds a List of Interceptors by Interceptor type and {@link Operation} Id.
+     *
+     * @param type        The type of Interceptor
+     * @param operationId The Operation Id
+     * @return The List of Interceptor associated
+     */
+    List<Interceptor> findByTypeAndOperationId(TypeInterceptor type, Long operationId);
 
-     /**
-      * Finds a List of Interceptors by Interceptor type and {@link Api} Id.
-      *
-      * @param  type			The type of Interceptor
-	  * @param  apiId			The Api Id
-      * @return					The List of Interceptor associated
-	  */
-     List<Interceptor> findByTypeAndOperationResourceApiId(TypeInterceptor type, Long apiId);
+    /**
+     * Finds a List of Interceptors by Interceptor type and {@link Api} Id.
+     *
+     * @param type  The type of Interceptor
+     * @param apiId The Api Id
+     * @return The List of Interceptor associated
+     */
+    List<Interceptor> findByTypeAndOperationResourceApiId(TypeInterceptor type, Long apiId);
 
-	 /**
-	  * Finds all Interceptors by {@link Operation} Id.
-	  *
-	  * @param operationId		The Operation Id
-	  * @return					The List of Interceptor associated
-	  */
-	 List<Interceptor> findByOperationId(Long operationId);
+    /**
+     * Finds all Interceptors by {@link Operation} Id.
+     *
+     * @param operationId The Operation Id
+     * @return The List of Interceptor associated
+     */
+    List<Interceptor> findByOperationId(Long operationId);
 
-	 /**
-	  * Finds all Interceptors by {@link Resource} Id.
-	  *
-	  * @param resourceId       The Resource Id
-	  * @return                 The List of Interceptor associated
-	  */
-	 List<Interceptor> findByResourceId(Long resourceId);
+    /**
+     * Finds all Interceptors by {@link Resource} Id.
+     *
+     * @param resourceId The Resource Id
+     * @return The List of Interceptor associated
+     */
+    List<Interceptor> findByResourceId(Long resourceId);
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/InterceptorRepository.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/InterceptorRepository.java
@@ -10,9 +10,9 @@ package br.com.conductor.heimdall.core.repository;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,19 +40,19 @@ import br.com.conductor.heimdall.core.enums.TypeInterceptor;
  *
  */
 public interface InterceptorRepository extends JpaRepository<Interceptor, Long> {
-     
+
 	 /**
 	  * Finds a List of Interceptors by Interceptor type and {@link Plan} Id.
-	  * 
+	  *
 	  * @param  type			The type of Interceptor
 	  * @param  planId			The Plan Id.
 	  * @return					The List of Interceptor associated
 	  */
      List<Interceptor> findByTypeAndPlanId(TypeInterceptor type, Long planId);
-     
+
      /**
       * Finds a List of Interceptors by Interceptor type and {@link Resource} Id.
-      * 
+      *
       * @param  type			The type of Interceptor
 	  * @param  resourceId		The Resource Id
       * @return					The List of Interceptor associated
@@ -61,16 +61,16 @@ public interface InterceptorRepository extends JpaRepository<Interceptor, Long> 
 
      /**
       * Finds a List of Interceptors by Interceptor type and {@link Operation} Id.
-      * 
+      *
       * @param  type			The type of Interceptor
 	  * @param  operationId		The Operation Id
       * @return					The List of Interceptor associated
 	  */
      List<Interceptor> findByTypeAndOperationId(TypeInterceptor type, Long operationId);
-     
+
      /**
       * Finds a List of Interceptors by Interceptor type and {@link Api} Id.
-      * 
+      *
       * @param  type			The type of Interceptor
 	  * @param  apiId			The Api Id
       * @return					The List of Interceptor associated
@@ -88,8 +88,8 @@ public interface InterceptorRepository extends JpaRepository<Interceptor, Long> 
 	 /**
 	  * Finds all Interceptors by {@link Resource} Id.
 	  *
-	  * @param resourceId		The Resource Id
-	  * @return					The List of Interceptor associated
+	  * @param resourceId       The Resource Id
+	  * @return                 The List of Interceptor associated
 	  */
 	 List<Interceptor> findByResourceId(Long resourceId);
 

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/InterceptorRepository.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/InterceptorRepository.java
@@ -36,6 +36,7 @@ import br.com.conductor.heimdall.core.enums.TypeInterceptor;
  * Provides methods to access a {@link Interceptor}
  *
  * @author Filipe Germano
+ * @author Marcelo Aguiar Rodrigues
  *
  */
 public interface InterceptorRepository extends JpaRepository<Interceptor, Long> {
@@ -75,5 +76,21 @@ public interface InterceptorRepository extends JpaRepository<Interceptor, Long> 
       * @return					The List of Interceptor associated
 	  */
      List<Interceptor> findByTypeAndOperationResourceApiId(TypeInterceptor type, Long apiId);
-          
+
+	 /**
+	  * Finds all Interceptors by {@link Operation} Id.
+	  *
+	  * @param operationId		The Operation Id
+	  * @return					The List of Interceptor associated
+	  */
+	 List<Interceptor> findByOperationId(Long operationId);
+
+	 /**
+	  * Finds all Interceptors by {@link Resource} Id.
+	  *
+	  * @param resourceId		The Resource Id
+	  * @return					The List of Interceptor associated
+	  */
+	 List<Interceptor> findByResourceId(Long resourceId);
+
 }


### PR DESCRIPTION
**Describe the feature**

A Operation can have Interceptors attached to it, so when deleting a Operations all the Interceptors attached must be deleted aswell.

The same goes for Resources that can have either Interceptors or Operations with or without Interceptors. So when service must delete all its children when deleting the parent.

This pull request treats this sort of scenario in the back end. The front end must warn the user when using any of these services.