### PR TITLE
[BUGFIX] clientId verification

### DIFF
--- a/heimdall-gateway/src/main/resources/template-interceptor/access_token.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/access_token.mustache
@@ -107,7 +107,7 @@ public class AccessTokenInterceptor extends HeimdallFilter {
                clientId = request.getParameter(nameClientId);       
           }
 
-          securityService.validadeAccessToken(ctx, helper, getApiId(), clientId, accessToken);       
+          securityService.validadeAccessToken(ctx, getApiId(), clientId, accessToken);
 
      }     
 

--- a/heimdall-gateway/src/main/resources/template-interceptor/client_id.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/client_id.mustache
@@ -103,7 +103,7 @@ public class ClientIdInterceptor extends HeimdallFilter {
                clientId = request.getParameter(name);               
           }
           
-          securityService.validadeClientId(ctx, helper, getApiId(), clientId);
+          securityService.validadeClientId(ctx, getApiId(), clientId);
      }
      
 }

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/HeimdallDecorationFilterTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/HeimdallDecorationFilterTest.java
@@ -1,6 +1,26 @@
 
 package br.com.conductor.heimdall.gateway.filter;
 
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
 import br.com.conductor.heimdall.core.entity.Api;
 import br.com.conductor.heimdall.core.entity.Environment;
 import br.com.conductor.heimdall.core.entity.Operation;
@@ -33,8 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.REQUEST_URI_KEY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -162,7 +181,7 @@ public class HeimdallDecorationFilterTest {
         this.filter.run();
 
         assertEquals("/api/foo", this.ctx.get(REQUEST_URI_KEY));
-        assertEquals(true, this.ctx.sendZuulResponse());
+        assertTrue(this.ctx.sendZuulResponse());
     }
 
     @Test
@@ -189,7 +208,7 @@ public class HeimdallDecorationFilterTest {
 
         this.filter.run();
 
-        assertEquals(false, this.ctx.sendZuulResponse());
+        assertFalse(this.ctx.sendZuulResponse());
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED.value(), this.ctx.getResponseStatusCode());
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED.getReasonPhrase(), this.ctx.getResponseBody());
     }

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/service/SecurityServiceTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/service/SecurityServiceTest.java
@@ -1,0 +1,201 @@
+
+package br.com.conductor.heimdall.gateway.service;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import br.com.conductor.heimdall.core.entity.Api;
+import br.com.conductor.heimdall.core.entity.App;
+import br.com.conductor.heimdall.core.entity.Developer;
+import br.com.conductor.heimdall.core.entity.Plan;
+import br.com.conductor.heimdall.core.repository.AppRepository;
+import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
+import com.netflix.zuul.context.RequestContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+public class SecurityServiceTest {
+
+    @InjectMocks
+    private SecurityService securityService;
+
+    @Mock
+    private AppRepository appRepository;
+
+    private RequestContext ctx;
+
+    private MockHttpServletRequest request = new MockHttpServletRequest();
+
+    private MockHttpServletResponse response = new MockHttpServletResponse();
+
+    private String clientId;
+
+    private String someOtherClientId;
+
+    private Api api1;
+
+    private Api api2;
+
+    private App app;
+
+    @Before
+    public void initTest() {
+        MockitoAnnotations.initMocks(this);
+
+        ctx = RequestContext.getCurrentContext();
+        ctx.clear();
+        ctx.setRequest(this.request);
+        ctx.setResponse(this.response);
+        TraceContextHolder.getInstance().init(true, "developer", request, false);
+
+        clientId = "simpleId";
+        someOtherClientId = "someOtherClientId";
+
+        api1 = new Api();
+        api1.setId(10L);
+
+        api2 = new Api();
+        api2.setId(20L);
+
+        Plan plan1 = new Plan();
+        plan1.setApi(api1);
+
+        Plan plan2 = new Plan();
+        plan2.setApi(api2);
+
+        List<Plan> planList = Arrays.asList(plan1, plan2);
+
+        Developer developer = new Developer();
+        developer.setEmail("some@email.com");
+
+        app = new App();
+        app.setPlans(planList);
+        app.setDeveloper(developer);
+        app.setClientId(clientId);
+
+    }
+
+    @Test
+    public void successCaseTest() {
+
+        Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
+
+        securityService.validadeClientId(this.ctx, api1.getId(), clientId);
+
+        // Internal Server Error is expected because the request has no finished at this
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), this.ctx.getResponseStatusCode());
+    }
+
+    @Test
+    public void successCase2Test() {
+
+        Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
+
+        securityService.validadeClientId(this.ctx, api2.getId(), clientId);
+
+        // Internal Server Error is expected because the request has no finished at this
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), this.ctx.getResponseStatusCode());
+    }
+
+    @Test
+    public void clientIdNullTest() {
+
+        securityService.validadeClientId(this.ctx, 10L, null);
+
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
+        assertTrue((Boolean) this.ctx.get(INTERRUPT));
+        assertFalse(ctx.sendZuulResponse());
+    }
+
+    @Test
+    public void apiIdNullTest() {
+
+        securityService.validadeClientId(this.ctx, null, clientId);
+
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
+        assertTrue((Boolean) this.ctx.get(INTERRUPT));
+        assertFalse(ctx.sendZuulResponse());
+
+    }
+
+    @Test
+    public void unauthorizedClientIdTest() {
+
+        Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
+
+        securityService.validadeClientId(this.ctx, api1.getId(), someOtherClientId);
+
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
+        assertTrue((Boolean) this.ctx.get(INTERRUPT));
+        assertFalse(ctx.sendZuulResponse());
+
+    }
+
+    @Test
+    public void apiNotInPlanTest() {
+
+        Api api = new Api();
+        api.setId(30L);
+
+        Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
+
+        securityService.validadeClientId(this.ctx, api.getId(), clientId);
+
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
+        assertTrue((Boolean) this.ctx.get(INTERRUPT));
+        assertFalse(ctx.sendZuulResponse());
+    }
+
+    @Test
+    public void planNotInAppTest() {
+
+        Api api = new Api();
+        api.setId(30L);
+
+        Plan plan = new Plan();
+        plan.setApi(api);
+
+        Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
+
+        securityService.validadeClientId(this.ctx, api.getId(), clientId);
+
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
+        assertTrue((Boolean) this.ctx.get(INTERRUPT));
+        assertFalse(ctx.sendZuulResponse());
+    }
+}

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/util/RouteSortTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/util/RouteSortTest.java
@@ -1,4 +1,25 @@
+
 package br.com.conductor.heimdall.gateway.util;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -15,8 +36,8 @@ import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 public class RouteSortTest {
 
 	
-     List<ZuulRoute> expected = new LinkedList<>();
-     List<ZuulRoute> actual = new LinkedList<>();
+     private List<ZuulRoute> expected = new LinkedList<>();
+     private List<ZuulRoute> actual = new LinkedList<>();
      
      @After
      public void afterTestMethod() {


### PR DESCRIPTION
**Describe the bug**
The client id verification would allow a a request with a invalid client id to go through.
The error was caused by a misplaced verification in the SecurityService class that caused a nullpointer exception that was not properly handled.