### PR TITLE
Operation path and Api base path refactoring

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/ApiService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/ApiService.java
@@ -34,6 +34,7 @@ import br.com.conductor.heimdall.core.exception.HeimdallException;
 import br.com.conductor.heimdall.core.repository.ApiRepository;
 import br.com.conductor.heimdall.core.service.amqp.AMQPRouteService;
 import br.com.conductor.heimdall.core.util.Pageable;
+import br.com.conductor.heimdall.core.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
@@ -74,7 +75,6 @@ public class ApiService {
       *
       * @param 	id						The ID of the {@link Api}
       * @return							The {@link Api}
-      * @throws	NotFoundException		Resource not found
       */
      public Api find(Long id) {
 
@@ -109,7 +109,6 @@ public class ApiService {
       * Generates a list of the {@link Api}'s
       *
       * @param 	apiDTO					{@link ApiDTO}
-      * @param 	pageableDTO				The pageable DTO
       * @return 						The list of {@link Api}'s
       */
      public List<Api> list(ApiDTO apiDTO) {
@@ -128,9 +127,6 @@ public class ApiService {
       *
       * @param 	apiDTO					{@link ApiDTO}
       * @return							The saved {@link Api}
-      * @throws	BadRequestException		The basepath defined exist
-      * @throws     BadRequestException      Api basepath can not contain wild card
-      * @throws     BadRequestException      Basepath can not be empty
       */
      public Api save(ApiDTO apiDTO) {
 
@@ -141,6 +137,7 @@ public class ApiService {
           HeimdallException.checkThrow(validateInboundsEnvironments(apiDTO.getEnvironments()), API_CANT_ENVIRONMENT_INBOUND_URL_EQUALS);
 
           Api api = GenericConverter.mapperWithMapping(apiDTO, Api.class, new ApiMap());
+          api.setBasePath(StringUtils.removeMultipleSlashes(api.getBasePath()));
 
           api = apiRepository.save(api);
 
@@ -154,10 +151,6 @@ public class ApiService {
       * @param 	id						The ID of the {@link Api}
       * @param 	apiDTO					{@link ApiDTO}
       * @return							The updated {@link Api}
-      * @throws	NotFoundException		Resource not found
-      * @throws	BadRequestException		The basepath defined exist
-      * @throws     BadRequestException      Api basepath can not contain wild card
-      * @throws     BadRequestException      Basepath can not be empty
       */
      public Api update(Long id, ApiDTO apiDTO) {
 
@@ -171,10 +164,11 @@ public class ApiService {
           HeimdallException.checkThrow(validateInboundsEnvironments(apiDTO.getEnvironments()), API_CANT_ENVIRONMENT_INBOUND_URL_EQUALS);
 
           api = GenericConverter.mapperWithMapping(apiDTO, api, new ApiMap());
+          api.setBasePath(StringUtils.removeMultipleSlashes(api.getBasePath()));
+
           api = apiRepository.save(api);
 
           amqpRoute.dispatchRoutes();
-
           return api;
      }
 
@@ -182,7 +176,6 @@ public class ApiService {
       * Deletes a {@link Api} by its ID.
       *
       * @param 	id						The ID of the {@link Api}
-      * @throws	NotFoundException		Resource not found
       */
      public void delete(Long id) {
 

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OperationService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OperationService.java
@@ -91,7 +91,6 @@ public class OperationService {
       * @param 	resourceId					The {@link Resource} Id
       * @param 	operationId					The {@link Operation} Id
       * @return								The {@link Operation} found
-      * @throws NotFoundException			Resource not found
       */
      @Transactional(readOnly = true)
      public Operation find(Long apiId, Long resourceId, Long operationId) {
@@ -110,7 +109,6 @@ public class OperationService {
       * @param 	operationDTO				The {@link OperationDTO}
       * @param 	pageableDTO					The {@link PageableDTO}
       * @return								The paged {@link Operation} list as a {@link OperationPage} object
-      * @throws NotFoundException			Resource not found
       */
      @Transactional(readOnly = true)
      public OperationPage list(Long apiId, Long resourceId, OperationDTO operationDTO, PageableDTO pageableDTO) {
@@ -125,10 +123,8 @@ public class OperationService {
           
           Pageable pageable = Pageable.setPageable(pageableDTO.getOffset(), pageableDTO.getLimit());
           Page<Operation> page = operationRepository.findAll(example, pageable);
-          
-          OperationPage operationPage = new OperationPage(PageDTO.build(page));
-          
-          return operationPage;
+
+          return new OperationPage(PageDTO.build(page));
      }
 
      /**
@@ -138,7 +134,6 @@ public class OperationService {
       * @param 	resourceId					The {@link Resource} Id
       * @param 	operationDTO				The {@link OperationDTO}
       * @return								The list of {@link Operation}
-      * @throws NotFoundException			Resource not found
       */
      @Transactional(readOnly = true)
      public List<Operation> list(Long apiId, Long resourceId, OperationDTO operationDTO) {
@@ -150,10 +145,8 @@ public class OperationService {
           operation.setResource(resource);
           
           Example<Operation> example = Example.of(operation, ExampleMatcher.matching().withIgnorePaths("resource.api").withIgnoreCase().withStringMatcher(StringMatcher.CONTAINING));
-          
-          List<Operation> operations = operationRepository.findAll(example);
-          
-          return operations;
+
+          return operationRepository.findAll(example);
      }
      
      /**
@@ -163,8 +156,6 @@ public class OperationService {
       * @param 	resourceId					The {@link Resource} Id
       * @param 	operationDTO				The {@link OperationDTO}
       * @return								The saved {@link Operation}
-      * @throws NotFoundException			Resource not found
-      * @throws	BadRequestException			Only one operation per resource
       */
      @Transactional
      public Operation save(Long apiId, Long resourceId, OperationDTO operationDTO) {
@@ -196,8 +187,6 @@ public class OperationService {
       * @param 	operationId					The {@link Operation} Id
       * @param 	operationDTO				The {@link OperationDTO}
       * @return								The updated {@link Operation}
-      * @throws NotFoundException			Resource not found
-      * @throws BadRequestException			Only one operation per resource
       */
      @Transactional
      public Operation update(Long apiId, Long resourceId, Long operationId, OperationDTO operationDTO) {
@@ -228,7 +217,6 @@ public class OperationService {
       * @param  apiId						The {@link Api} Id
       * @param 	resourceId					The {@link Resource} Id
       * @param 	operationId					The {@link Operation} Id
-      * @throws NotFoundException			Resource not found
       */
      @Transactional
      public void delete(Long apiId, Long resourceId, Long operationId) {

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/StringUtils.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/StringUtils.java
@@ -39,7 +39,6 @@ public abstract class StringUtils {
 	 * @param  prefix					The number to be prefixed
 	 * @param  order					The order
 	 * @return							The prefixed order created
-	 * @throws BadRequestException
 	 */
      public static String generateOrder(Integer prefix, Integer order) {
 
@@ -57,7 +56,7 @@ public abstract class StringUtils {
       */
      public static String concatCamelCase(String... strings) {
           
-          String value = "";
+          StringBuilder value = new StringBuilder();
           for (String string : strings) {
                
                String[] splits = string.split("_");
@@ -65,12 +64,12 @@ public abstract class StringUtils {
                     
                     if (Objeto.notBlank(split)) {
                          
-                         value += split.substring(0, 1).toUpperCase() + split.substring(1).toLowerCase();
+                         value.append(split.substring(0, 1).toUpperCase()).append(split.substring(1).toLowerCase());
                     }
                }
           }
           
-          return value;          
+          return value.toString();
      }
 
      /**
@@ -98,4 +97,17 @@ public abstract class StringUtils {
           
      }
 
+    /**
+     * Removes all instances of double forward slash from a path and
+     * makes sure that there is one forward slash at the start of the
+     * path.
+     *
+     * @param path Path to be parsed
+     * @return     The path with one forward slash at the start and
+     *             single forward slashes where there were double
+     */
+     public static String removeMultipleSlashes(String path) {
+         path = "/" + path;
+         return path.replaceAll("//+", "/");
+     }
 }

--- a/heimdall-frontend/src/components/apis/ApiDefinition.js
+++ b/heimdall-frontend/src/components/apis/ApiDefinition.js
@@ -104,9 +104,9 @@ class ApiDefinition extends Component {
                                     <FormItem label="Base path">
                                         {
                                             getFieldDecorator('basePath', {
-                                                initialValue: api.basePath,
+                                                initialValue: api.basePath.replace("/", ""),
                                                 rules: [{ required: true, message: 'Please input your api base path!' }]
-                                            })(<Input />)
+                                            })(<Input addonBefore={"/"}/>)
                                         }
                                     </FormItem>
                                 </Col>

--- a/heimdall-frontend/src/components/apis/NewApiOverview.js
+++ b/heimdall-frontend/src/components/apis/NewApiOverview.js
@@ -73,7 +73,7 @@ class NewApiOverview extends Component {
                                     {
                                         getFieldDecorator('basePath', {
                                             rules: [{ required: true, message: 'Please input your api base path!' }]
-                                        })(<Input placeholder="/basepath" />)
+                                        })(<Input addonBefore={"/"} placeholder="basepath" />)
                                     }
                                 </FormItem>
                             </Col>

--- a/heimdall-frontend/src/components/operations/OperationForm.js
+++ b/heimdall-frontend/src/components/operations/OperationForm.js
@@ -67,7 +67,7 @@ class OperationForm extends Component {
                                     getFieldDecorator('path', {
                                         initialValue: this.props.operation && this.props.operation.path,
                                         rules: [{ required: true, message: 'Please input your api path!' }]
-                                    })(<Input required />)
+                                    })(<Input addonBefore={this.props.apiBasepath + "/"} required />)
                                 }
                             </FormItem>
                         </Col>
@@ -89,7 +89,8 @@ class OperationForm extends Component {
 
 OperationForm.propTypes = {
     idApi: PropTypes.number.isRequired,
-    idResource: PropTypes.number.isRequired
+    idResource: PropTypes.number.isRequired,
+    apiBasepath: PropTypes.number.isRequired
 }
 
 const mapStateToProps = state => {

--- a/heimdall-frontend/src/containers/Operations.js
+++ b/heimdall-frontend/src/containers/Operations.js
@@ -109,7 +109,7 @@ class Operations extends Component {
                 visible={this.state.visibleModal}
                 onCancel={this.handleCancel}
                 destroyOnClose >
-                <OperationForm onRef={ref => (this.operationForm = ref)} onSubmit={this.submitPayload} operationId={this.state.operationSelected} idApi={this.props.idApi} idResource={this.props.idResource} />
+                <OperationForm onRef={ref => (this.operationForm = ref)} onSubmit={this.submitPayload} operationId={this.state.operationSelected} idApi={this.props.idApi} idResource={this.props.idResource} apiBasepath={this.props.apiBasepath}/>
             </Modal>
 
         if (operations && operations.length === 0) {
@@ -186,7 +186,8 @@ class Operations extends Component {
 
 Operations.propType = {
     idApi: PropTypes.number.isRequired,
-    idResource: PropTypes.number.isRequired
+    idResource: PropTypes.number.isRequired,
+    apiBasepath: PropTypes.number.isRequired
 }
 
 const mapStateToProps = state => {

--- a/heimdall-frontend/src/containers/Resources.js
+++ b/heimdall-frontend/src/containers/Resources.js
@@ -134,7 +134,7 @@ class Resources extends Component {
                                     </ButtonGroup>
                                 </Row>
                             } extraWidth={10}>
-                                <Operations idResource={resource.id} idApi={api.id} />
+                                <Operations idResource={resource.id} idApi={api.id} apiBasepath={api.basePath} />
                             </HeimdallPanel>
                         )
                     })}


### PR DESCRIPTION
Changes have been made to the Operation path and Api base path verification in the back end and in the front end to make the new rules clearer to the users.

* Back end
    * Added method to enforce this list of rules to a Operation path and an Api basepath:
        * always start with a forward slash 
        * can not have multiple forward slashes together ( "//" )
        * can not have a forward slash at the end

* Front end
    * OperationForm now shows the Api base path as a prefix of the Operation path field.
    * ApiDetails page and Api creation page now show the base path forward slash in the base path field.