### PR TITLE
Keep the same code based on version 1.2.2

### DIFF
--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -44,7 +44,7 @@ heimdall:
     mongo:
         enabled: false
 #        serverName:
-#        url:
+#        url: mongodb://admin:admin@localhost:27017
 #        port: 27017
 #        dataBase: logging
 #        collection: logs

--- a/heimdall-config/src/main/resources/shared/gateway.yml
+++ b/heimdall-config/src/main/resources/shared/gateway.yml
@@ -19,12 +19,13 @@ heimdall:
 
 zuul:
     #servletPath: /
+    ignoredPatterns: /manager/**
     include-debug-header: false
     debug: 
         parameter: debug
         request: false
     filter: 
-        interval: 5
+        interval: 8
     host: 
         socket-timeout-millis: 40000
         connect-timeout-millis: 40000        

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/HeimdallHandlerMapping.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/HeimdallHandlerMapping.java
@@ -48,11 +48,15 @@ public class HeimdallHandlerMapping extends ZuulHandlerMapping {
      @Override
      protected Object lookupHandler(String urlPath, HttpServletRequest request) throws Exception {
 
-          if (this.dirty) {
-               registerHandler("/**", this.zuul);
-               setDirty(false);
-          }
-          return super.lookupHandler(urlPath, request);
+    	 if (this.dirty) {
+ 			synchronized (this) {
+ 				if (this.dirty) {
+ 					registerHandler("/**", this.zuul);
+ 					setDirty(false);
+ 				}
+ 			}
+ 		}
+        return super.lookupHandler(urlPath, request);
      }
 
      public void setDirty(boolean dirty) {

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/ZuulConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/ZuulConfiguration.java
@@ -21,15 +21,12 @@ package br.com.conductor.heimdall.gateway.configuration;
  * ==========================LICENSE_END===================================
  */
 
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.commons.httpclient.ApacheHttpClientConnectionManagerFactory;
-import org.springframework.cloud.commons.httpclient.ApacheHttpClientFactory;
 import org.springframework.cloud.netflix.zuul.ZuulProxyAutoConfiguration;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
@@ -98,12 +95,10 @@ public class ZuulConfiguration extends ZuulProxyAutoConfiguration {
      }
 
      @Bean
-     @ConditionalOnMissingBean({SimpleHostRoutingFilter.class, CloseableHttpClient.class})
+     @ConditionalOnMissingBean({SimpleHostRoutingFilter.class})
      public SimpleHostRoutingFilter simpleHostRoutingFilter(ProxyRequestHelper helper,
-                                                            ZuulProperties zuulProperties,
-                                                            ApacheHttpClientConnectionManagerFactory connectionManagerFactory,
-                                                            ApacheHttpClientFactory httpClientFactory) {
-          return new CustomHostRoutingFilter(helper, zuulProperties, connectionManagerFactory, httpClientFactory);
+                                                            ZuulProperties zuulProperties) {
+          return new CustomHostRoutingFilter(helper, zuulProperties);
      }
 
      @Bean

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CustomHostRoutingFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CustomHostRoutingFilter.java
@@ -26,8 +26,6 @@ import java.net.URL;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.http.HttpHost;
-import org.springframework.cloud.commons.httpclient.ApacheHttpClientConnectionManagerFactory;
-import org.springframework.cloud.commons.httpclient.ApacheHttpClientFactory;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.route.SimpleHostRoutingFilter;
@@ -57,10 +55,8 @@ public class CustomHostRoutingFilter extends SimpleHostRoutingFilter {
       * @param helper		{@link ProxyRequestHelper}
       * @param properties	{@link ZuulProperties}
       */
-     public CustomHostRoutingFilter(ProxyRequestHelper helper, ZuulProperties properties,
-                                    ApacheHttpClientConnectionManagerFactory connectionManagerFactory,
-                                    ApacheHttpClientFactory httpClientFactory) {
-          super(helper, properties, connectionManagerFactory, httpClientFactory);
+     public CustomHostRoutingFilter(ProxyRequestHelper helper, ZuulProperties properties) {
+          super(helper, properties);
           this.helper = helper;
      }
      

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 		<hikaricp.version>2.6.1</hikaricp.version>
 		<mssql-jdbc.version>6.2.1.jre8</mssql-jdbc.version>
 		<jackson.version>2.9.2</jackson.version>
-		<spring-cloud.version>Edgware.SR4</spring-cloud.version>
+		<spring-cloud.version>Dalston.SR5</spring-cloud.version>
 		<scala.version>2.11.7</scala.version>
 		<gatling.version>2.2.0</gatling.version>
 		<scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>


### PR DESCRIPTION
*Ignoring "/manager/**" in zuul
*Rollback the spring cloud and gateway to keep the same code based on version 1.2.2