### PR TITLE
[HOT-FIX] Mongo to use AsyncAppender and removed config health

### DIFF
--- a/heimdall-api/src/main/resources/bootstrap-docker.yml
+++ b/heimdall-api/src/main/resources/bootstrap-docker.yml
@@ -5,3 +5,6 @@ spring:
     config:
       uri: http://heimdall-config:8888
       fail-fast: true
+health:
+  config:
+    enabled: false

--- a/heimdall-api/src/main/resources/bootstrap.yml
+++ b/heimdall-api/src/main/resources/bootstrap.yml
@@ -5,3 +5,6 @@ spring:
     config:
       uri: http://localhost:8888
       fail-fast: true
+health:
+  config:
+    enabled: false

--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -44,12 +44,14 @@ heimdall:
     mongo:
         enabled: false
 #        serverName:
-#        url: mongodb://admin:admin@localhost:27017
+#        url: mongodb://localhost
 #        port: 27017
 #        dataBase: logging
 #        collection: logs
 #        username: admin
 #        password: admin
+#        queueSize: 500
+#        discardingThreshold: 0
     trace:
         printAllTrace: true
         sanitizes:

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
@@ -31,6 +31,7 @@ import lombok.Data;
  * This class represents the environment.
  * 
  * @author Filipe Germano
+ * @author Marcelo Aguiar Rodrigues
  *
  */
 @Data
@@ -150,6 +151,8 @@ public class Property {
           private String collection;
           private String username;
           private String password;
+          private Long queueSize;
+          private Long discardingThreshold;
           
      }
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
@@ -9,9 +9,9 @@ package br.com.conductor.heimdall.gateway.appender;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,37 +20,31 @@ package br.com.conductor.heimdall.gateway.appender;
  * ==========================LICENSE_END===================================
  */
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.bson.Document;
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientURI;
-import com.mongodb.ServerAddress;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.mongodb.*;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.AppenderBase;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class provides a appender service to a MongoDB database.
- * 
+ *
  * @author Marcos Filho
- * @see AppenderBase
+ * @author Marcelo Aguiar Rodrigues
  *
  */
 @Slf4j
 @NoArgsConstructor
-public class MongoDBAppender extends AppenderBase<ILoggingEvent> {
+public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
 	private MongoClient mongoClient;
 	private MongoCollection<Document> collection;
@@ -90,7 +84,7 @@ public class MongoDBAppender extends AppenderBase<ILoggingEvent> {
 		if (this.uri != null) {
 			this.mongoClient = new MongoClient(new MongoClientURI(this.uri));
 		} else {
-			MongoClientOptions options = new MongoClientOptions.Builder().socketKeepAlive(true).build();
+			MongoClientOptions options = new MongoClientOptions.Builder().build();
 			ServerAddress address = new ServerAddress(this.url, this.port.intValue());
 			this.mongoClient = new MongoClient(address, options);
 		}

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
@@ -48,6 +48,9 @@ import javax.annotation.PostConstruct;
 @Configuration
 public class LogConfiguration {
 
+     private static final int DEFAULT_QUEUE_SIZE = 500;
+     private static final int DEFAULT_DISCARDING_THRESHOLD = 0;
+
      @Autowired
      private Property property;
      
@@ -70,9 +73,12 @@ public class LogConfiguration {
              appender.start();
 
              // Creating AsyncAppender
+             int queueSize = (property.getMongo().getQueueSize() != null) ? property.getMongo().getQueueSize().intValue() : DEFAULT_QUEUE_SIZE;
+             int discardingThreshold = (property.getMongo().getDiscardingThreshold() != null) ? property.getMongo().getDiscardingThreshold().intValue() : DEFAULT_DISCARDING_THRESHOLD;
+
              Appender<ILoggingEvent> asyncAppender = new AsyncAppender();
-             ((AsyncAppender) asyncAppender).setQueueSize(property.getMongo().getQueueSize().intValue());
-             ((AsyncAppender) asyncAppender).setDiscardingThreshold(property.getMongo().getDiscardingThreshold().intValue());
+             ((AsyncAppender) asyncAppender).setQueueSize(queueSize);
+             ((AsyncAppender) asyncAppender).setDiscardingThreshold(discardingThreshold);
              ((AsyncAppender) asyncAppender).addAppender(appender);
              asyncAppender.start();
 

--- a/heimdall-gateway/src/main/resources/bootstrap-docker.yml
+++ b/heimdall-gateway/src/main/resources/bootstrap-docker.yml
@@ -5,3 +5,6 @@ spring:
     config:
       uri: http://heimdall-config:8888
       fail-fast: true
+health:
+  config:
+    enabled: false

--- a/heimdall-gateway/src/main/resources/bootstrap.yml
+++ b/heimdall-gateway/src/main/resources/bootstrap.yml
@@ -5,3 +5,6 @@ spring:
     config:
       uri: http://localhost:8888
       fail-fast: true
+health:
+  config:
+    enabled: false


### PR DESCRIPTION
**HOT-FIX**

1. Wrapped MongoDBAppender with a AsyncAppender to make it mo resilient to mongodb failures
    This prevents Heimdall to stop answering and queue requests if the connection to the MongoDB drops.

2. Api and Gateway should not check the config's health
    When performing their health check the Api and Gateway have no need to check the Config's health.