### PR TITLE
Filters not being registered

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/HeimdallHandlerMapping.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/HeimdallHandlerMapping.java
@@ -21,21 +21,18 @@ package br.com.conductor.heimdall.gateway.configuration;
  * ==========================LICENSE_END===================================
  */
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.cloud.netflix.zuul.web.ZuulController;
 import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
 
 /**
- * Extends {@link ZuulHandlerMapping} to add a dirty checking.
+ * Extends {@link ZuulHandlerMapping} to register the routes at the application start.
  *
  * @author Marcos Filho
+ * @author Marcelo Aguiar Rodrigues
  *
  */
 public class HeimdallHandlerMapping extends ZuulHandlerMapping {
-
-     private volatile boolean dirty = true;
 
      private final ZuulController zuul;
 
@@ -45,24 +42,8 @@ public class HeimdallHandlerMapping extends ZuulHandlerMapping {
           this.zuul = zuul;
      }
 
-     @Override
-     protected Object lookupHandler(String urlPath, HttpServletRequest request) throws Exception {
-
-    	 if (this.dirty) {
- 			synchronized (this) {
- 				if (this.dirty) {
- 					registerHandler("/**", this.zuul);
- 					setDirty(false);
- 				}
- 			}
- 		}
-        return super.lookupHandler(urlPath, request);
-     }
-
-     public void setDirty(boolean dirty) {
-
-          this.dirty = dirty;
-          super.setDirty(false);
+     public void initHandlers() {
+         registerHandler("/**", this.zuul);
      }
 
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/HeimdallHandlerMapping.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/HeimdallHandlerMapping.java
@@ -25,6 +25,8 @@ import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.cloud.netflix.zuul.web.ZuulController;
 import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Extends {@link ZuulHandlerMapping} to register the routes at the application start.
  *
@@ -36,10 +38,32 @@ public class HeimdallHandlerMapping extends ZuulHandlerMapping {
 
      private final ZuulController zuul;
 
+     private volatile boolean dirty = true;
+
      public HeimdallHandlerMapping(RouteLocator routeLocator, ZuulController zuul) {
 
           super(routeLocator, zuul);
           this.zuul = zuul;
+     }
+
+     @Override
+     protected Object lookupHandler(String urlPath, HttpServletRequest request) throws Exception {
+
+          if (this.dirty) {
+               synchronized (this) {
+                    if (this.dirty) {
+                         registerHandler("/**", this.zuul);
+                         setDirty(false);
+                    }
+               }
+          }
+          return super.lookupHandler(urlPath, request);
+     }
+
+     public void setDirty(boolean dirty) {
+
+          this.dirty = dirty;
+          super.setDirty(false);
      }
 
      public void initHandlers() {

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/ZuulConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/ZuulConfiguration.java
@@ -115,9 +115,8 @@ public class ZuulConfiguration extends ZuulProxyAutoConfiguration {
 
      }
 
-     @Override
-     public HeimdallHandlerMapping zuulHandlerMapping(RouteLocator routes) {
-
+     @Bean
+     public HeimdallHandlerMapping heimdallHandlerMapping() {
           HeimdallHandlerMapping handlerMapping = new HeimdallHandlerMapping(proxyRouteLocator(), zuulController());
           handlerMapping.setErrorController(this.errorController);
           return handlerMapping;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/ZuulConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/ZuulConfiguration.java
@@ -115,8 +115,8 @@ public class ZuulConfiguration extends ZuulProxyAutoConfiguration {
 
      }
 
-     @Bean
-     public HeimdallHandlerMapping heimdallHandlerMapping() {
+     @Override
+     public HeimdallHandlerMapping zuulHandlerMapping(RouteLocator routes) {
           HeimdallHandlerMapping handlerMapping = new HeimdallHandlerMapping(proxyRouteLocator(), zuulController());
           handlerMapping.setErrorController(this.errorController);
           return handlerMapping;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/Middleware.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/Middleware.java
@@ -120,7 +120,7 @@ public class Middleware {
              ? Arrays.stream(entries)
                   .filter(e -> filter.accept(directory, e.getName()))
                   .max(Comparator.comparingLong(File::lastModified))
-                  .get()
+                  .orElse(null)
              : null;
 
      }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/listener/MiddlewareListener.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/listener/MiddlewareListener.java
@@ -67,6 +67,7 @@ public class MiddlewareListener {
                if (Objeto.notBlank(middleware)) {
                     
                     log.info("Updating/Creating middleware id: " + middlewareId);
+                    startServer.addApiDirectoryToPath(middleware.getApi());
                     startServer.createMiddlewaresInterceptor(middlewareId);
                     startServer.loadMiddlewareFiles(middlewareId);
                } else {

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/listener/StartServer.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/listener/StartServer.java
@@ -30,6 +30,7 @@ import br.com.conductor.heimdall.core.repository.InterceptorRepository;
 import br.com.conductor.heimdall.core.repository.MiddlewareRepository;
 import br.com.conductor.heimdall.core.service.FileService;
 import br.com.conductor.heimdall.core.util.Constants;
+import br.com.conductor.heimdall.gateway.configuration.HeimdallHandlerMapping;
 import br.com.conductor.heimdall.gateway.service.InterceptorFileService;
 import br.com.twsoftware.alfred.io.Arquivo;
 import br.com.twsoftware.alfred.object.Objeto;
@@ -80,7 +81,10 @@ public class StartServer implements ServletContextListener {
 
      @Autowired 
      private FileService fileService;
-     
+
+     @Autowired
+     private HeimdallHandlerMapping heimdallHandlerMapping;
+
      @Value("${zuul.filter.root}")
      private String zuulFilterRoot;
 
@@ -93,6 +97,7 @@ public class StartServer implements ServletContextListener {
      public void contextInitialized(ServletContextEvent sce) {
 
           log.info("Initializing Groovy Interceptors");
+          heimdallHandlerMapping.initHandlers();
           initGroovyFilterManager();
 
      }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/util/HeimdallFilterFileManager.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/util/HeimdallFilterFileManager.java
@@ -1,0 +1,186 @@
+package br.com.conductor.heimdall.gateway.util;
+
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+
+import com.netflix.zuul.FilterLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Custom FilterFileManager created to be able to add directories dynamically to be scanned for new scripts.
+ *
+ * @author Marcelo Aguiar Rodrigues
+ * @see com.netflix.zuul.FilterFileManager
+ */
+public class HeimdallFilterFileManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeimdallFilterFileManager.class);
+    private Set<String> aDirectories;
+    private int pollingIntervalSeconds;
+    private Thread poller;
+    private boolean bRunning = true;
+    private static FilenameFilter FILENAME_FILTER;
+    private static HeimdallFilterFileManager INSTANCE;
+
+    private HeimdallFilterFileManager() {
+    }
+
+    public static void setFilenameFilter(FilenameFilter filter) {
+        FILENAME_FILTER = filter;
+    }
+
+    /**
+     * Initialized the GroovyFileManager.
+     *
+     * @param pollingIntervalSeconds the polling interval in Seconds
+     * @param directories            Any number of paths to directories to be polled may be specified
+     * @throws IOException
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     */
+    public static void init(int pollingIntervalSeconds, Set<String> directories) throws Exception, IllegalAccessException, InstantiationException {
+        if (INSTANCE == null) INSTANCE = new HeimdallFilterFileManager();
+        INSTANCE.aDirectories = directories;
+        INSTANCE.pollingIntervalSeconds = pollingIntervalSeconds;
+        INSTANCE.manageFiles();
+        INSTANCE.startPoller();
+    }
+
+    public static HeimdallFilterFileManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Shuts down the poller
+     */
+    public static void shutdown() {
+        INSTANCE.stopPoller();
+    }
+
+    void stopPoller() {
+        bRunning = false;
+    }
+
+    void startPoller() {
+        poller = new Thread("HeimdallGroovyFilterFileManagerPoller") {
+            public void run() {
+                while (bRunning) {
+                    try {
+                        sleep(pollingIntervalSeconds * 1000);
+                        manageFiles();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        };
+        poller.setDaemon(true);
+        poller.start();
+    }
+
+    /**
+     * Returns the directory File for a path. A Runtime Exception is thrown if the directory is in valid
+     *
+     * @param sPath
+     * @return a File representing the directory path
+     */
+    public File getDirectory(String sPath) {
+        File directory = new File(sPath);
+        if (!directory.isDirectory()) {
+            URL resource = HeimdallFilterFileManager.class.getClassLoader().getResource(sPath);
+            try {
+                directory = new File(resource.toURI());
+            } catch (Exception e) {
+                LOG.error("Error accessing directory in classloader. path=" + sPath, e);
+            }
+            if (!directory.isDirectory()) {
+                throw new RuntimeException(directory.getAbsolutePath() + " is not a valid directory");
+            }
+        }
+        return directory;
+    }
+
+    /**
+     * Returns a List<File> of all Files from all polled directories
+     *
+     * @return
+     */
+    List<File> getFiles() {
+        List<File> list = new ArrayList<>();
+        for (String sDirectory : aDirectories) {
+            if (sDirectory != null) {
+                File directory = getDirectory(sDirectory);
+                File[] aFiles = directory.listFiles(FILENAME_FILTER);
+                if (aFiles != null) {
+                    list.addAll(Arrays.asList(aFiles));
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * puts files into the FilterLoader. The FilterLoader will only addd new or changed filters
+     *
+     * @param aFiles a List<File>
+     * @throws IOException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    void processGroovyFiles(List<File> aFiles) throws Exception, InstantiationException, IllegalAccessException {
+        for (File file : aFiles) {
+            FilterLoader.getInstance().putFilter(file);
+        }
+    }
+
+    void manageFiles() throws Exception, IllegalAccessException, InstantiationException {
+        List<File> aFiles = getFiles();
+        processGroovyFiles(aFiles);
+    }
+
+    /**
+     * Addes a new directory to be scanned
+     *
+     * @param directory path to the directory
+     */
+    public void addNewDirectory(String directory) {
+        aDirectories.add(directory);
+    }
+
+    /**
+     * Removes a directory from the path
+     *
+     * @param directory directory to be removed
+     */
+    public void removeDirectory(String directory) {
+        aDirectories.remove(directory);
+    }
+}
+


### PR DESCRIPTION
This pull request solves two issues related to new Api and new routes creation.

## 1. Filters not being registered
This is a long time problem that Heimdall had. Under some circumstances request would not pass through any of the filters. Even paths that are correct would not work. Only a restart of the gateway would fix that.

That was caused by the routes not being registered properly. Now the initial routes are registered at the start of the application. This change should prevent that problem from happening in the future.

## 2. Adding a middleware to a new Api
There was a issue that prevented a middleware to work when attached to a new Api.

**Steps to reproduce**
1. Create a Api
2. Create Resource and Operation
3. Add a middleware to this Api
4. Add a interceptor to the new Operation to use the new Middleware
5. Call the operation (see error)

Restart the gateway and it would work fine. The problem was that the folder for the new Api was not being added to the FilterFileManager. To solve that a custom FilterFileManager that allows for dynamic creation of new folders was added.