### PR TITLE
[HOTFIX] Middleware file response not working

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
@@ -463,25 +463,7 @@ public class CallImpl implements Call {
 
           @Override
           public void setBody(byte[] body) {
-               
-               InputStream stream;
-               try {
-                    if (body != null) {
-
-                         stream = new ByteArrayInputStream(body);
-                    } else {
-                         
-                         stream = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
-                    }
-                    context.setSendZuulResponse(false);
-                    context.setResponseDataStream(stream);
-                    writeResponse(stream, context.getResponse().getOutputStream(), body);
-               } catch (UnsupportedEncodingException e) {
-                   log.error(e.getMessage(), e);
-               } catch (IOException e) {
-                   e.printStackTrace();
-               }
-
+              setBody(body, false);
           }
 
          @Override

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
@@ -20,16 +20,16 @@ package br.com.conductor.heimdall.gateway.filter.helper;
  * ==========================LICENSE_END===================================
  */
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -61,6 +61,7 @@ import lombok.extern.slf4j.Slf4j;
  * Implementation of the {@link Call} interface.
  *
  * @author Filipe Germano
+ * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
  *
  */
 @Slf4j
@@ -463,25 +464,57 @@ public class CallImpl implements Call {
           @Override
           public void setBody(byte[] body) {
                
-               ByteArrayInputStream stream;
+               InputStream stream;
                try {
                     if (body != null) {
-                         
+
                          stream = new ByteArrayInputStream(body);
                     } else {
                          
-                         stream = new ByteArrayInputStream("".getBytes("UTF-8"));;
+                         stream = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
                     }
-                    
                     context.setSendZuulResponse(false);
                     context.setResponseDataStream(stream);
+                    writeResponse(stream, context.getResponse().getOutputStream(), body);
                } catch (UnsupportedEncodingException e) {
-                    
-                    log.error(e.getMessage(), e);
+                   log.error(e.getMessage(), e);
+               } catch (IOException e) {
+                   e.printStackTrace();
                }
-               
+
           }
-          
+
+         @Override
+         public void setBody(byte[] body, boolean gzip) {
+
+             InputStream stream;
+             try {
+                 if (body != null) {
+                     stream = new ByteArrayInputStream(body);
+                     if (gzip) {
+                         stream = new GZIPInputStream(stream);
+                     }
+                 } else {
+                     stream = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
+                 }
+                 context.setSendZuulResponse(false);
+                 context.setResponseDataStream(stream);
+                 writeResponse(stream, context.getResponse().getOutputStream(), body);
+
+             } catch (UnsupportedEncodingException e) {
+                 log.error(e.getMessage(), e);
+             } catch (IOException e) {
+                 e.printStackTrace();
+             }
+
+         }
+
+         private void writeResponse(InputStream zin, OutputStream out, byte[] body) throws IOException {
+             int bytesRead = -1;
+             while ((bytesRead = zin.read(body)) != -1) {
+                 out.write(body, 0, bytesRead);
+             }
+         }
      }
      
      @Override

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/spec/Response.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/spec/Response.java
@@ -25,6 +25,7 @@ package br.com.conductor.heimdall.middleware.spec;
  * This interface provides methods to control a response.
  *
  * @author Filipe Germano
+ * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
  *
  */
 public interface Response {
@@ -34,39 +35,47 @@ public interface Response {
 	  * 
 	  * @return			The header of a response
 	  */
-     public Header header();
+     Header header();
      
      /**
       * Gets the status code of a response.
       * 
       * @return			The status code of a response.
       */
-     public Integer getStatus();
+     Integer getStatus();
      
      /**
       * Sets the status code of a response.
       * @param status	The the status code of a response
       */
-     public void setStatus(Integer status);
+     void setStatus(Integer status);
      
      /**
       * Gets the body of a response.
       * 
       * @return			The body of a response.
       */
-     public String getBody();
+     String getBody();
      
      /**
       * Sets the body of a response.
       * 
       * @param body		The String representation of body of a response
       */
-     public void setBody(String body);
+     void setBody(String body);
      
      /**
       * Sets the body of a response.
       * 
       * @param body		The byte array representation of body of a response
       */
-     public void setBody(byte[] body);
+     void setBody(byte[] body);
+
+    /**
+     * Sets the body of a response.
+     *
+     * @param body		The byte array representation of body of a response
+     * @param gzip      Gzip the response
+     */
+     void setBody(byte[] body, boolean gzip);
 }

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/ResponseMock.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/call/ResponseMock.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
  * Mock class created to help unit test the root request class of a middleware.
  *
  * @author Marcelo Aguiar
+ * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
  */
 public class ResponseMock implements Response {
 
@@ -63,6 +64,11 @@ public class ResponseMock implements Response {
 
     @Override
     public void setBody(byte[] body) {
+        this.body = Arrays.toString(body);
+    }
+
+    @Override
+    public void setBody(byte[] body, boolean gzip) {
         this.body = Arrays.toString(body);
     }
 }


### PR DESCRIPTION
**Describe the bug**
When a middleware received a file from the backend Heimdall would not set the response correctly.

**To Reproduce**
Steps to reproduce the behavior:
1. Create a middleware that consumes an Api that returns a file
2. Try to consume this resource
3. The downloaded file would come back empty from Heimdall even if the backend was working correctly.

**Expected behavior**
Heimdall should not interfere with a file download.
