### PR TITLE
Adding HTTP PATCH method support

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.6.7-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<packaging>jar</packaging>

--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.6.7-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<packaging>jar</packaging>

--- a/heimdall-config/pom.xml
+++ b/heimdall-config/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.6.7-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-config</artifactId>
 	<name>heimdall-config</name>

--- a/heimdall-config/pom.xml
+++ b/heimdall-config/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.6.7-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-config</artifactId>
 	<name>heimdall-config</name>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.6.7-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.6.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.6.7-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.6.7-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.6.7-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.6.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/spec/Http.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/spec/Http.java
@@ -110,6 +110,14 @@ public interface Http {
       * @return			A ApiResponse object
       */
      public ApiResponse sendDelete();
+     
+     /**
+     Sends a PATCH request to the Api and receives a {@link ApiResponse}.
+     * 
+     * @return			A ApiResponse object
+     * @author José Roberto <zeroberto>
+     */
+    public ApiResponse sendPatch();
 
     /**
      * Set RestTemplate custom object

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
@@ -24,6 +24,8 @@ package br.com.conductor.heimdall.middleware.util.helpermock;
 import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Http;
 import br.com.conductor.heimdall.middleware.spec.Json;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
@@ -123,4 +125,16 @@ public class HttpMockImpl implements Http {
     public RestTemplate clientProvider(RestTemplate restTemplate) {
         return new RestTemplate();
     }
+
+    /**
+     * Method responsible for testing request calls using the HTTP PATCH verb.
+     * 
+     * @author José Roberto <zeroberto>
+     */
+	@Override
+	public ApiResponse sendPatch() {
+		ApiResponse response = new ApiResponseMockImpl();
+		response.setStatus(HttpStatus.NO_CONTENT.value());
+		return response;
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>1.6.7-SNAPSHOT</version>
+	<version>1.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -247,12 +247,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>1.6.7-SNAPSHOT</version>
+				<version>1.7.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>1.6.7-SNAPSHOT</version>
+				<version>1.7.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>1.7.0-SNAPSHOT</version>
+	<version>1.6.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -247,12 +247,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>1.7.0-SNAPSHOT</version>
+				<version>1.6.7-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>1.7.0-SNAPSHOT</version>
+				<version>1.6.7-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>


### PR DESCRIPTION
**On this pull request:**
- Adding the sendPatch() method to the Http interface and its respective implementation in HttpImpl, so that the architecture supports the call of requests through the HTTP PATCH method;

- Modifying the RestTemplate object to support new Http methods, such as PATCH.