### PR TITLE
Adding HTTP PATCH method support

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
@@ -10,9 +10,9 @@ package br.com.conductor.heimdall.gateway.filter.helper;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -73,6 +74,7 @@ public class HttpImpl implements Http {
 		this.enableHandler = enableHandler;
 	}
 
+	@Override
 	public HttpImpl header(String name, String value) {
 
 		if (Objeto.notBlank(value)) {
@@ -83,6 +85,7 @@ public class HttpImpl implements Http {
 		return this;
 	}
 
+	@Override
 	public HttpImpl header(Map<String, String> params) {
 
 		params.forEach((key, value) -> {
@@ -93,6 +96,7 @@ public class HttpImpl implements Http {
 		return this;
 	}
 
+	@Override
 	public HttpImpl url(String url) {
 
 		uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(url);
@@ -100,6 +104,7 @@ public class HttpImpl implements Http {
 		return this;
 	}
 
+	@Override
 	public HttpImpl queryParam(String name, String value) {
 
 		if (Objeto.notBlank(value)) {
@@ -110,6 +115,7 @@ public class HttpImpl implements Http {
 		return this;
 	}
 
+	@Override
 	public HttpImpl body(Map<String, Object> params) {
 
 		if (headers.containsKey("Content-Type")
@@ -127,6 +133,7 @@ public class HttpImpl implements Http {
 		return this;
 	}
 
+	@Override
 	public HttpImpl body(String params) {
 
 		body = json.parse(params);
@@ -135,6 +142,7 @@ public class HttpImpl implements Http {
 
 	}
 
+	@Override
 	public ApiResponseImpl sendGet() {
 
 		ResponseEntity<String> entity;
@@ -156,6 +164,7 @@ public class HttpImpl implements Http {
 		return apiResponse;
 	}
 
+	@Override
 	public ApiResponseImpl sendPost() {
 
 		ResponseEntity<String> entity;
@@ -190,6 +199,7 @@ public class HttpImpl implements Http {
 		return apiResponse;
 	}
 
+	@Override
 	public ApiResponseImpl sendPut() {
 
 		ResponseEntity<String> entity;
@@ -220,6 +230,7 @@ public class HttpImpl implements Http {
 		return apiResponse;
 	}
 
+	@Override
 	public ApiResponseImpl sendDelete() {
 
 		ResponseEntity<String> entity;
@@ -240,21 +251,50 @@ public class HttpImpl implements Http {
 		return apiResponse;
 	}
 
-	private RestTemplate rest() {
-		if (this.restTemplate == null) {
+	@Override
+	public ApiResponseImpl sendPatch() {
 
-			this.restTemplate = new RestTemplate();
+		ResponseEntity<String> entity;
+
+		if (headers.isEmpty()) {
+			requestBody = new HttpEntity<>(body);
+			entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.PATCH, requestBody,
+					String.class);
+		} else {
+			if (Objeto.notBlank(formData)) {
+				HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(formData, headers);
+				entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.PATCH, request,
+						String.class);
+			} else {
+				requestBody = new HttpEntity<>(body, headers);
+				entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.PATCH, requestBody,
+						String.class);
+			}
 		}
 
-		if (enableHandler) {
-			this.restTemplate.setErrorHandler(new HeimdallResponseErrorHandler());			
-		}
-		return this.restTemplate;
+		ApiResponseImpl apiResponse = new ApiResponseImpl();
+		apiResponse.setHeaders(entity.getHeaders().toSingleValueMap());
+		apiResponse.setBody(entity.getBody());
+		apiResponse.setStatus(entity.getStatusCodeValue());
+
+		return apiResponse;
 	}
 
+	@Override
 	public RestTemplate clientProvider(RestTemplate restTemplate) {
 
 		this.restTemplate = restTemplate;
+		return this.restTemplate;
+	}
+
+	private RestTemplate rest() {
+		if (this.restTemplate == null) {
+			this.restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+		}
+
+		if (enableHandler) {
+			this.restTemplate.setErrorHandler(new HeimdallResponseErrorHandler());
+		}
 		return this.restTemplate;
 	}
 

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/spec/Http.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/spec/Http.java
@@ -112,6 +112,13 @@ public interface Http {
      public ApiResponse sendDelete();
 
     /**
+     * Sends a PATCH request to the Api and receives a {@link ApiResponse}.
+     *
+     * @return			A ApiResponse object
+     */
+    public ApiResponse sendPatch();
+
+    /**
      * Set RestTemplate custom object
      * @return               A RestTemplate object
      */

--- a/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
+++ b/heimdall-middleware-spec/src/main/java/br/com/conductor/heimdall/middleware/util/helpermock/HttpMockImpl.java
@@ -24,6 +24,8 @@ package br.com.conductor.heimdall.middleware.util.helpermock;
 import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Http;
 import br.com.conductor.heimdall.middleware.spec.Json;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
@@ -117,6 +119,16 @@ public class HttpMockImpl implements Http {
     @Override
     public ApiResponse sendDelete() {
         return this.sendGet();
+    }
+
+    /**
+     * Method responsible for testing request calls using the HTTP PATCH verb.
+     */
+    @Override
+    public ApiResponse sendPatch() {
+        ApiResponse response = new ApiResponseMockImpl();
+        response.setStatus(HttpStatus.NO_CONTENT.value());
+        return response;
     }
 
     @Override


### PR DESCRIPTION
**On this pull request:**
- Adding the sendPatch() method to the Http interface and its respective implementation in HttpImpl, so that the architecture supports the call of requests through the HTTP PATCH method;
- Modifying the RestTemplate object to support new Http methods, such as PATCH.