### PR TITLE
Cache interceptor refactoring

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/interceptor/impl/CacheClearHeimdallInterceptor.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/interceptor/impl/CacheClearHeimdallInterceptor.java
@@ -62,8 +62,6 @@ public class CacheClearHeimdallInterceptor implements HeimdallInterceptor {
         CacheDTO cacheDTO = (CacheDTO) objectCustom;
 
         parameters.put("cache", cacheDTO.getCache());
-        parameters.put("headers", cacheDTO.getHeaders());
-        parameters.put("queryParams", cacheDTO.getQueryParams());
 
         return parameters;
     }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/CacheService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/CacheService.java
@@ -47,7 +47,6 @@ public class CacheService {
       */
      public List<String> list() {
           
-//          List<String> cacheNames = Lists.newArrayList(cacheManager.getCacheNames());
           List<String> cacheNames = new ArrayList<>(cacheManager.getCacheNames());
           
           return cacheNames;

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/TemplateUtils.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/TemplateUtils.java
@@ -36,5 +36,5 @@ public class TemplateUtils {
      public static final String TEMPLATE_OAUTH = "{\"providerId\": 1 , \"typeOAuth\":\"GENERATE\", \"timeAccessToken\":20, \"timeRefreshToken\":1800, \"privateKey\":\"privateKey\" }";
      public static final String TEMPLATE_BLOCK_IPS = "{\"ips\": [ \"127.0.0.0\", \"127.0.0.1\" ]}";
      public static final String TEMPLATE_CACHE = "{\"cache\":\"cache-name\", \"timeToLive\": 10000, \"headers\": [\"header1\", \"header2\"], \"queryParams\": [\"queryParam1\", \"queryParam2\"]}";
-     public static final String TEMPLATE_CACHE_CLEAR = "{\"cache\":\"cache-name\", \"headers\": [\"header\"], \"queryParams\": [\"queryParam\"]";
+     public static final String TEMPLATE_CACHE_CLEAR = "{\"cache\":\"cache-name\"}";
 }

--- a/heimdall-frontend/src/utils/InterceptorUtils.js
+++ b/heimdall-frontend/src/utils/InterceptorUtils.js
@@ -3,7 +3,7 @@ export const TEMPLATE_MOCK = "{\"body\": \"{'name': 'Mock Example'}\", \"status\
 export const TEMPLATE_RATTING = "{\"calls\":20,\"interval\":\"MINUTES\"}";
 export const TEMPLATE_IPS = "{\"ips\": [ \"127.0.0.0\", \"127.0.0.1\" ]}";
 export const TEMPLATE_CACHE = "{\"cache\":\"cache-name\", \"timeToLive\": 10000, \"headers\": [\"header1\", \"header2\"], \"queryParams\": [\"queryParam1\", \"queryParam2\"]}";
-export const TEMPLATE_CACHE_CLEAR = "{\"cache\":\"cache-name\", \"headers\": [\"header1\", \"header2\"], \"queryParams\": [\"queryParam1\", \"queryParam2\"]}";
+export const TEMPLATE_CACHE_CLEAR = "{\"cache\":\"cache-name\"}";
 
 export const getTemplate = (type) => {
     if (type === 'ACCESS_TOKEN') {

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/CacheInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/CacheInterceptorService.java
@@ -121,16 +121,19 @@ public class CacheInterceptorService {
                 "headers" + headersBuilder.toString();
     }
 
+    /*
+     * Creates a cache key to delete the cache
+     */
     private String createDeleteCacheKey(RequestContext context, String cacheName) {
 
-        String apiId = (String) context.get("api-id");
-        String apiName = (String) context.get("api-name");
-
-        return apiId + "-" + apiName + ":" +
-                cacheName + ":" +
-                context.getRequest().getRequestURL().toString() + "*";
+        return context.get("api-id") + "-" +
+                context.get("api-name") + ":" +
+                cacheName + ":*";
     }
 
+    /*
+     * Defines if the cache should be written
+     */
     private boolean shouldCache(RequestContext context, List<String> headers, List<String> queryParams) {
 
         Map<String, List<String>> requestQueryParams = (context.getRequestQueryParams() != null) ? context.getRequestQueryParams() : new HashMap<>();

--- a/heimdall-gateway/src/main/resources/template-interceptor/cache_clear.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/cache_clear.mustache
@@ -26,10 +26,6 @@ public class CacheClearInterceptor extends ZuulFilter {
 
     private static String cacheName;
 
-    private static List<String> headers;
-
-    private static List<String> queryParams;
-
     private CacheInterceptorService cacheInterceptorService;
 
     private FilterDetail detail;
@@ -39,16 +35,6 @@ public class CacheClearInterceptor extends ZuulFilter {
         cacheName = "{{cache}}";
 
         method = "{{method}}";
-
-        headers = Lists.newArrayList();
-        {{#headers}}
-        headers.add("{{.}}");
-        {{/headers}}
-
-        queryParams = Lists.newArrayList();
-        {{#queryParams}}
-        queryParams.add("{{.}}");
-        {{/queryParams}}
 
         pathsAllowed = Sets.newHashSet();
         {{#pathsAllowed}}
@@ -96,7 +82,7 @@ public class CacheClearInterceptor extends ZuulFilter {
     private void process() {
         cacheInterceptorService = (CacheInterceptorService) BeanManager.getBean(CacheInterceptorService.class);
 
-        cacheInterceptorService.cacheClearInterceptor(cacheName, headers, queryParams);
+        cacheInterceptorService.cacheClearInterceptor(cacheName);
         return null;
     }
 


### PR DESCRIPTION
Cache invalidation was would not delete all caches from a path if it had multiple calls with different headers/queryparams. That might couse some caches not to be deleted when they should.

 Now the invalidation will clear all caches at once, preventing that problem.