### PR TITLE
HOTFIX - Plan verification

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/LifeCycleService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/LifeCycleService.java
@@ -23,7 +23,9 @@ import br.com.conductor.heimdall.core.entity.App;
 import br.com.conductor.heimdall.core.entity.Plan;
 import br.com.conductor.heimdall.core.enums.HttpMethod;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
+import br.com.conductor.heimdall.core.enums.Status;
 import br.com.conductor.heimdall.core.repository.AppRepository;
+import br.com.conductor.heimdall.core.repository.PlanRepository;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,9 @@ public class LifeCycleService {
 
     @Autowired
     private AppRepository appRepository;
+
+    @Autowired
+    private PlanRepository planRepository;
 
     private static PathMatcher pathMatcher = new AntPathMatcher();
 
@@ -93,6 +98,11 @@ public class LifeCycleService {
 
     private boolean validatePlan(Set<String> pathsAllowed, Set<String> pathsNotAllowed, String inboundURL, HttpServletRequest req, Long referenceId) {
 
+        final Plan plan1 = planRepository.findOne(referenceId);
+        if (plan1 != null)
+            if (!Status.ACTIVE.equals(plan1.getStatus()))
+                return false;
+
         if ((inboundURL != null && !inboundURL.isEmpty()) &&
                 !isHostValidToInboundURL(req, inboundURL)) {
             return false;
@@ -118,7 +128,7 @@ public class LifeCycleService {
 
             for (String path : pathsAllowed) {
 
-                if (req.getRequestURI().contains(path)) return true;
+                if (pathMatcher.match(req.getRequestURI(), path)) return true;
             }
         }
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/LifeCycleService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/LifeCycleService.java
@@ -229,9 +229,9 @@ public class LifeCycleService {
 
         String clientId;
         if (Location.HEADER.equals(location))
-            clientId = req.getHeader(name);
+            clientId = req.getHeader("client_id");
         else
-            clientId = req.getParameter(name);
+            clientId = req.getParameter("client_id");
 
         String accessToken;
         if (Location.HEADER.equals(location))

--- a/heimdall-gateway/src/main/resources/template-interceptor/access_token.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/access_token.mustache
@@ -15,7 +15,7 @@ import br.com.conductor.heimdall.gateway.filter.helper.*;
 import br.com.conductor.heimdall.core.entity.AccessToken;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.enums.Location;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.service.SecurityService;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
@@ -79,7 +79,10 @@ public class AccessTokenInterceptor extends HeimdallFilter {
      public boolean should() {
 
         LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
-        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+        return lifeCycleService.validateAccessToken(RequestContext.getCurrentContext().getRequest(),
+                                                        getApiId(),
+                                                        Location.valueOf("{{location}}"),
+                                                        "{{name}}");
      }
      
      @Override

--- a/heimdall-gateway/src/main/resources/template-interceptor/blacklist_ip.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/blacklist_ip.mustache
@@ -6,7 +6,7 @@ import com.netflix.zuul.ZuulFilter;
 import com.google.common.collect.Sets;
 import com.netflix.zuul.context.RequestContext;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
 import br.com.conductor.heimdall.middleware.spec.*;

--- a/heimdall-gateway/src/main/resources/template-interceptor/cache.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/cache.mustache
@@ -2,7 +2,7 @@ import java.util.*;
 
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.util.BeanManager;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.service.CacheInterceptorService;

--- a/heimdall-gateway/src/main/resources/template-interceptor/cache_clear.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/cache_clear.mustache
@@ -1,7 +1,7 @@
 import java.util.*;
 
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.core.util.Constants;
 import br.com.conductor.heimdall.gateway.service.CacheInterceptorService;

--- a/heimdall-gateway/src/main/resources/template-interceptor/client_id.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/client_id.mustache
@@ -15,7 +15,7 @@ import br.com.conductor.heimdall.gateway.filter.helper.*;
 import br.com.conductor.heimdall.core.entity.App;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.enums.Location;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.service.SecurityService;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
@@ -78,7 +78,10 @@ public class ClientIdInterceptor extends HeimdallFilter {
      public boolean should() {
 
         LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
-        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+        return lifeCycleService.validateClientId(RequestContext.getCurrentContext().getRequest(),
+                                                    getApiId(),
+                                                    Location.valueOf("{{location}}"),
+                                                    "{{name}}");
      }
      
      @Override
@@ -93,22 +96,22 @@ public class ClientIdInterceptor extends HeimdallFilter {
      @Override
      public void execute() throws Throwable {
 
-          securityService = (SecurityService) BeanManager.getBean(SecurityService.class);
-          RequestContext ctx = RequestContext.getCurrentContext();
-          HttpServletRequest request = ctx.getRequest();
-          
-          String clientId = null;
-          Location location = Location.valueOf("{{location}}");
-          String name = "{{name}}";
-          if (Location.HEADER.equals(location)) {
-               
-               clientId = helper.call().request().header().get(name);
-          }else {
-
-               clientId = request.getParameter(name);               
-          }
-          
-          securityService.validadeClientId(ctx, getApiId(), clientId);
+//          securityService = (SecurityService) BeanManager.getBean(SecurityService.class);
+//          RequestContext ctx = RequestContext.getCurrentContext();
+//          HttpServletRequest request = ctx.getRequest();
+//
+//          String clientId = null;
+//          Location location = Location.valueOf("{{location}}");
+//          String name = "{{name}}";
+//          if (Location.HEADER.equals(location)) {
+//
+//               clientId = helper.call().request().header().get(name);
+//          }else {
+//
+//               clientId = request.getParameter(name);
+//          }
+//
+//          securityService.validadeClientId(ctx, getApiId(), clientId);
      }
      
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/custom.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/custom.mustache
@@ -4,7 +4,7 @@ import com.google.common.collect.Sets;
 import com.netflix.zuul.context.RequestContext;
 
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.gateway.filter.helper.*;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;

--- a/heimdall-gateway/src/main/resources/template-interceptor/identifier.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/identifier.mustache
@@ -1,4 +1,5 @@
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
 import br.com.conductor.heimdall.middleware.spec.Helper;
@@ -20,6 +21,8 @@ public class UniqueID extends HeimdallFilter {
 
     private static String method;
 
+    private static Long referenceId;
+
     private Helper helper;
 
     public UniqueID() {
@@ -38,12 +41,16 @@ public class UniqueID extends HeimdallFilter {
 
         inboundURL = "{{inboundURL}}";
 
+        referenceId = {{referenceId}};
+
         this.helper = new HelperImpl();
     }
 
     @Override
     public boolean should() {
-        return InterceptorLifeCycle.{{lifeCycle}}.filter(pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest());
+
+        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
+        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
     }
 
     @Override

--- a/heimdall-gateway/src/main/resources/template-interceptor/middleware.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/middleware.mustache
@@ -6,7 +6,7 @@ import com.google.common.collect.Sets;
 import com.netflix.zuul.context.RequestContext;
 
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.gateway.filter.helper.*;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;

--- a/heimdall-gateway/src/main/resources/template-interceptor/mock.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/mock.mustache
@@ -6,7 +6,7 @@ import com.google.common.collect.Sets;
 import com.netflix.zuul.context.RequestContext;
 
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.filter.helper.*;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;

--- a/heimdall-gateway/src/main/resources/template-interceptor/oauth.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/oauth.mustache
@@ -6,7 +6,7 @@ import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.enums.TypeOAuth;
 import br.com.conductor.heimdall.core.exception.HeimdallException;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.gateway.filter.helper.*;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;

--- a/heimdall-gateway/src/main/resources/template-interceptor/ratting.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/ratting.mustache
@@ -18,7 +18,7 @@ import br.com.conductor.heimdall.core.entity.Interceptor;
 import br.com.conductor.heimdall.core.entity.RateLimit;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.enums.Interval;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.filter.helper.*;

--- a/heimdall-gateway/src/main/resources/template-interceptor/whitelist_ip.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/whitelist_ip.mustache
@@ -6,7 +6,7 @@ import com.netflix.zuul.ZuulFilter;
 import com.google.common.collect.Sets;
 import com.netflix.zuul.context.RequestContext;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
 import br.com.conductor.heimdall.middleware.spec.*;


### PR DESCRIPTION
**Describe the bug**
This pull request fixes a couple of bugs:
1. During the PLAN lifecycle verification it did not validate if the plan was had Status ACTIVE
1. During the PLAN lifecycle the verification of the patters used a String.contains method when it should be a PathMatcher.match method. This could cause a error when there was two Api's configured as follows.
  * Api 1:
    * basepath: /foo
  * Api 2:
    * basepath: /bar
    * operation: /foo

If a Plan interceptor is attached to Api 1, it would run when a call was made to the Api 2 /bar/foo