### PR TITLE
Hotfix - Popup error message might show wrong template

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/exception/ExceptionMessage.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/exception/ExceptionMessage.java
@@ -210,20 +210,22 @@ public enum ExceptionMessage {
      */
     public void raise(String... dynamicText) {
 
+        String messageDefault = this.defaultMessage;
+
         if (dynamicText != null && dynamicText.length > 0) {
 
             Integer count = 0;
-            String baseMessage = this.defaultMessage;
+            String baseMessage = messageDefault;
             while (baseMessage.contains("{}")) {
 
                 if (dynamicText.length == 1) {
 
-                    this.message = this.defaultMessage.replace("{}", dynamicText[count]);
+                    this.message = messageDefault.replace("{}", dynamicText[count]);
                     baseMessage = this.message;
                 } else {
 
-                    this.defaultMessage = this.defaultMessage.replaceFirst("\\{\\}", dynamicText[count]);
-                    this.message = this.defaultMessage;
+                    messageDefault = messageDefault.replaceFirst("\\{\\}", dynamicText[count]);
+                    this.message = messageDefault;
                     baseMessage = this.message;
 
                 }
@@ -232,6 +234,7 @@ public enum ExceptionMessage {
         }
         raise();
     }
+
 
     /**
      * Method responsible for validation of error codes with code 400.

--- a/heimdall-frontend/src/styles.less
+++ b/heimdall-frontend/src/styles.less
@@ -2,6 +2,8 @@ body {
     background: -moz-linear-gradient(top, rgba(242,245,246,0.5) 0%, rgba(242,245,246,0.5) 1%, rgba(227,234,237,0.62) 47%, rgba(200,215,220,0.76) 100%);
     background: -webkit-linear-gradient(top, rgba(242,245,246,0.5) 0%,rgba(242,245,246,0.5) 1%,rgba(227,234,237,0.62) 47%,rgba(200,215,220,0.76) 100%);
     background: linear-gradient(to bottom, rgba(242,245,246,0.5) 0%,rgba(242,245,246,0.5) 1%,rgba(227,234,237,0.62) 47%,rgba(200,215,220,0.76) 100%);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#80f2f5f6', endColorstr='#c2c8d7dc',GradientType=0 );
 }
 


### PR DESCRIPTION
**Describe the bug**
* When registering two or more interceptors with wrong contents, the error message shown is always the same as the first one;
* When there is scroll in the body, the linear-gradient in background is not fixed. 

**To Reproduce**
Steps to reproduce the behavior:
1. Go to Apis
2. Click on some API
3. Select tab Interceptors
4. Create a interceptor with content wrong and save
5. Create other interceptor of different type with wrong content and save
6. See error 

**Expected behavior**
The second error message should show the template for the correct interceptor.
