### PR TITLE
Fix plan lifecycle and log blacklist write

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
@@ -19,6 +19,26 @@
  */
 package br.com.conductor.heimdall.gateway.filter;
 
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+
 import br.com.conductor.heimdall.core.util.Constants;
 import br.com.conductor.heimdall.core.util.ContentTypeUtils;
 import br.com.conductor.heimdall.core.util.UrlUtil;
@@ -30,26 +50,6 @@ import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
 import br.com.conductor.heimdall.middleware.spec.Helper;
 import br.com.twsoftware.alfred.object.Objeto;
 import lombok.Cleanup;
-
-import com.netflix.util.Pair;
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.springframework.http.HttpHeaders;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StreamUtils;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
 
 /**
  * Logs the response to the trace

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
@@ -24,6 +24,7 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -135,7 +136,7 @@ public class LogResponseFilter extends ZuulFilter {
             	
             	r.setBody(body);
             }
-            ctx.setResponseDataStream(new ByteArrayInputStream(body.getBytes("UTF-8")));
+            ctx.setResponseDataStream(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
         }
         TraceContextHolder.getInstance().getActualTrace().setResponse(r);
     }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
@@ -125,7 +125,7 @@ public class LogResponseFilter extends ZuulFilter {
             InputStream stream = ctx.getResponseDataStream();
             String body;
 
-            body = StreamUtils.copyToString(stream, Charset.forName("UTF-8"));
+            body = StreamUtils.copyToString(stream, StandardCharsets.UTF_8);
 
             if (body.isEmpty() && helper.call().response().getBody() != null) {
             	

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
@@ -144,9 +144,12 @@ public class LogResponseFilter extends ZuulFilter {
         Map<String, String> headers = new HashMap<>();
 
         final HttpServletResponse response = context.getResponse();
+        
+        context.getZuulResponseHeaders().stream().forEach(pair -> headers.put(pair.first(), pair.second()));
+        
         final Collection<String> headerNames = response.getHeaderNames();
 
-        headerNames.forEach(s -> headers.put(s, response.getHeader(s)));
+        headerNames.forEach(s -> headers.putIfAbsent(s, response.getHeader(s)));       
 
         return headers;
     }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/SecurityService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/SecurityService.java
@@ -36,6 +36,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
 
@@ -108,25 +109,26 @@ public class SecurityService {
       * @param apiId    The apiId
       * @param clientId ClientId to be validated
       */
-     public void validadeClientId(RequestContext ctx, Long apiId, String clientId) {
+     public void validateClientId(RequestContext ctx, Long apiId, String clientId) {
 
           final String CLIENT_ID = "Client Id";
           
-          if (Objeto.notBlank(clientId)) {
+          if (Objects.nonNull(clientId)) {
                
                TraceContextHolder.getInstance().getActualTrace().setClientId(DigestUtils.digestMD5(clientId));
                App app = appRepository.findByClientId(clientId);
-               if (Objeto.isBlank(app)) {
+               if (Objects.isNull(app)) {
 
                     buildResponse(ctx, String.format(ConstantsInterceptors.GLOBAL_CLIENT_ID_OR_ACESS_TOKEN_NOT_FOUND, CLIENT_ID));
                } else {
 
                     Plan plan = app.getPlans().stream().filter(p -> apiId.equals(p.getApi().getId())).findFirst().orElse(null);
-                    if (Objeto.isBlank(plan)) {
+                    if (Objects.isNull(plan)) {
 
                          buildResponse(ctx, ConstantsInterceptors.GLOBAL_ACCESS_NOT_ALLOWED_API);
                     } else {
 
+                    	 TraceContextHolder.getInstance().getActualTrace().setApp(app.getName());
                          TraceContextHolder.getInstance().getActualTrace().setAppDeveloper(app.getDeveloper().getEmail());
                     }
                }

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/service/SecurityServiceTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/service/SecurityServiceTest.java
@@ -115,7 +115,7 @@ public class SecurityServiceTest {
 
         Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
 
-        securityService.validadeClientId(this.ctx, api1.getId(), clientId);
+        securityService.validateClientId(this.ctx, api1.getId(), clientId);
 
         // Internal Server Error is expected because the request has no finished at this
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), this.ctx.getResponseStatusCode());
@@ -126,7 +126,7 @@ public class SecurityServiceTest {
 
         Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
 
-        securityService.validadeClientId(this.ctx, api2.getId(), clientId);
+        securityService.validateClientId(this.ctx, api2.getId(), clientId);
 
         // Internal Server Error is expected because the request has no finished at this
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), this.ctx.getResponseStatusCode());
@@ -135,7 +135,7 @@ public class SecurityServiceTest {
     @Test
     public void clientIdNullTest() {
 
-        securityService.validadeClientId(this.ctx, 10L, null);
+        securityService.validateClientId(this.ctx, 10L, null);
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
         assertTrue((Boolean) this.ctx.get(INTERRUPT));
@@ -145,7 +145,7 @@ public class SecurityServiceTest {
     @Test
     public void apiIdNullTest() {
 
-        securityService.validadeClientId(this.ctx, null, clientId);
+        securityService.validateClientId(this.ctx, null, clientId);
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
         assertTrue((Boolean) this.ctx.get(INTERRUPT));
@@ -158,7 +158,7 @@ public class SecurityServiceTest {
 
         Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
 
-        securityService.validadeClientId(this.ctx, api1.getId(), someOtherClientId);
+        securityService.validateClientId(this.ctx, api1.getId(), someOtherClientId);
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
         assertTrue((Boolean) this.ctx.get(INTERRUPT));
@@ -174,7 +174,7 @@ public class SecurityServiceTest {
 
         Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
 
-        securityService.validadeClientId(this.ctx, api.getId(), clientId);
+        securityService.validateClientId(this.ctx, api.getId(), clientId);
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
         assertTrue((Boolean) this.ctx.get(INTERRUPT));
@@ -192,7 +192,7 @@ public class SecurityServiceTest {
 
         Mockito.when(appRepository.findByClientId(clientId)).thenReturn(app);
 
-        securityService.validadeClientId(this.ctx, api.getId(), clientId);
+        securityService.validateClientId(this.ctx, api.getId(), clientId);
 
         assertEquals(HttpStatus.UNAUTHORIZED.value(), this.ctx.getResponseStatusCode());
         assertTrue((Boolean) this.ctx.get(INTERRUPT));


### PR DESCRIPTION
*Actually when somebody put a interceptor with a PLAN lifecycle and don't put a valid client_id (app) then throw a Null Point Exception, this PR will fix this;

*Fix the problem when the log filter read the response headers, now we first check the zuulResponseHeader s and after that we check the servlet response headers