### PR TITLE
Log masker interceptor

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -79,12 +79,6 @@
 			<version>0.6</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.7.1</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -41,7 +41,6 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<!-- <version>${mssql-jdbc.version}</version> -->
 		</dependency>
 		<dependency>
 			<groupId>org.liquibase</groupId>
@@ -50,7 +49,6 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<!-- <version>${hikaricp.version}</version> -->
 		</dependency>
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
@@ -98,10 +96,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/interceptor/LogMaskDTO.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/interceptor/LogMaskDTO.java
@@ -1,18 +1,15 @@
-
-package br.com.conductor.heimdall.gateway.trace;
-
 /*-
  * =========================LICENSE_START==================================
- * heimdall-gateway
+ * heimdall-core
  * ========================================================================
  * Copyright (C) 2018 Conductor Tecnologia SA
  * ========================================================================
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,29 +17,25 @@ package br.com.conductor.heimdall.gateway.trace;
  * limitations under the License.
  * ==========================LICENSE_END===================================
  */
+package br.com.conductor.heimdall.core.dto.interceptor;
 
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Data;
 
+import java.util.List;
 /**
- * Data class a that represents a Request Response parser.
+ * Class is a Data Transfer Object for the LogMask Interceptor.
  *
- * @author Thiago Sampaio
  * @author Marcelo Aguiar Rodrigues
  */
 @Data
-public class RequestResponseParser {
+public class LogMaskDTO {
 
-     @JsonInclude(Include.NON_NULL)
-     private String uri;
+    private Boolean uri = false;
 
-     @JsonInclude(Include.NON_NULL)
-     private Map<String, String> headers;
+    private Boolean body = false;
 
-     @JsonInclude(Include.NON_NULL)
-     private String body;
+    private Boolean headers = false;
+
+    private List<String> ignoredHeaders = null;
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/enums/TypeInterceptor.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/enums/TypeInterceptor.java
@@ -48,7 +48,8 @@ public enum TypeInterceptor {
 	WHITELIST(new WhitelistHeimdallInterceptor()),
 	CACHE(new CacheHeimdallInterceptor()),
 	CACHE_CLEAR(new CacheClearHeimdallInterceptor()),
-	IDENTIFIER(new IdentifierHeimdallInterceptor());
+	IDENTIFIER(new IdentifierHeimdallInterceptor()),
+	LOG_MASKER(new LogMaskerHeimdallInterceptor());
 
 	private HeimdallInterceptor heimdallInterceptor;
 

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/interceptor/impl/LogMaskerHeimdallInterceptor.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/interceptor/impl/LogMaskerHeimdallInterceptor.java
@@ -1,0 +1,69 @@
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-core
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+package br.com.conductor.heimdall.core.interceptor.impl;
+
+import br.com.conductor.heimdall.core.dto.interceptor.LogMaskDTO;
+import br.com.conductor.heimdall.core.entity.Interceptor;
+import br.com.conductor.heimdall.core.enums.TypeExecutionPoint;
+import br.com.conductor.heimdall.core.enums.TypeInterceptor;
+import br.com.conductor.heimdall.core.exception.ExceptionMessage;
+import br.com.conductor.heimdall.core.interceptor.HeimdallInterceptor;
+import br.com.conductor.heimdall.core.util.JsonUtils;
+import br.com.conductor.heimdall.core.util.TemplateUtils;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+
+/**
+ * Implementation of the HeimdallInterceptor to type LogMask.
+ *
+ * @author Marcelo Aguiar Rodrigues
+ */
+@Slf4j
+public class LogMaskerHeimdallInterceptor implements HeimdallInterceptor {
+
+    @Override
+    public String getFile(TypeExecutionPoint typeExecutionPoint) {
+        return "log_masker.mustache";
+    }
+
+    @Override
+    public Object parseContent(String content) {
+        try {
+            return JsonUtils.convertJsonToObject(content, LogMaskDTO.class);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            ExceptionMessage.INTERCEPTOR_INVALID_CONTENT.raise(TypeInterceptor.LOG_MASKER.name(), TemplateUtils.TEMPLATE_LOG_MASKER);
+        }
+
+        return null;    }
+
+    @Override
+    public HashMap<String, Object> buildParameters(Object objectCustom, HashMap<String, Object> parameters, Interceptor interceptor) {
+        LogMaskDTO logMaskDTO = (LogMaskDTO) objectCustom;
+
+        parameters.put("body", logMaskDTO.getBody());
+        parameters.put("uri", logMaskDTO.getUri());
+        parameters.put("headers", logMaskDTO.getHeaders());
+        parameters.put("ignoredHeaders", logMaskDTO.getIgnoredHeaders());
+
+        return parameters;
+    }
+}

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/TemplateUtils.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/TemplateUtils.java
@@ -26,7 +26,7 @@ package br.com.conductor.heimdall.core.util;
  * 
  * @author Filipe Germano
  * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
- * 
+ * @author Marcelo Aguiar Rodrigues
  */
 public class TemplateUtils {
 
@@ -37,4 +37,5 @@ public class TemplateUtils {
      public static final String TEMPLATE_BLOCK_IPS = "{\"ips\": [ \"127.0.0.0\", \"127.0.0.1\" ]}";
      public static final String TEMPLATE_CACHE = "{\"cache\":\"cache-name\", \"timeToLive\": 10000, \"headers\": [\"header1\", \"header2\"], \"queryParams\": [\"queryParam1\", \"queryParam2\"]}";
      public static final String TEMPLATE_CACHE_CLEAR = "{\"cache\":\"cache-name\"}";
+     public static final String TEMPLATE_LOG_MASKER = "{\"body\":true,\"uri\":true,\"headers\":true,\"ignoredHeaders\":[\"headerName\"]}";
 }

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -19,11 +19,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20171018</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-zuul</artifactId>
 		</dependency>
@@ -56,11 +51,6 @@
 		<dependency>
 			<groupId>com.netflix.netflix-commons</groupId>
 			<artifactId>netflix-commons-util</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -228,16 +218,7 @@
 				<configuration>
 					<resultsFolder>${project.basedir}/target/gatling/results</resultsFolder>
 					<runMultipleSimulations>true</runMultipleSimulations>
-					<!-- <disableCompiler>true</disableCompiler> -->
-					<!-- <reportsOnly>ttt</reportsOnly> -->
-					<!-- <noReports>false</noReports> -->
 				</configuration>
-				<!-- <executions> -->
-				<!-- <execution> -->
-				<!-- <phase>test</phase> -->
-				<!-- <goals><goal>execute</goal></goals> -->
-				<!-- </execution> -->
-				<!-- </executions> -->
 			</plugin>
 			
 		</plugins>

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/LogMaskerService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/LogMaskerService.java
@@ -1,0 +1,89 @@
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+package br.com.conductor.heimdall.gateway.service;
+
+import br.com.conductor.heimdall.gateway.trace.RequestResponseParser;
+import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
+
+/**
+ * Log Mask Service provides a method to mask the information from the {@link br.com.conductor.heimdall.gateway.trace.Trace}.
+ *
+ * @author Marcelo Aguiar Rodrigues
+ */
+@Service
+public class LogMaskerService {
+
+    /**
+     * Given the filter type it removes the information passed from the {@link br.com.conductor.heimdall.gateway.trace.Trace}.
+     *
+     * @param filterType     {@link org.springframework.cloud.netflix.zuul.filters.support.FilterConstants}
+     * @param deleteBody     should delete the request body
+     * @param deleteUri      should delete the request uri
+     * @param headers        should delete the request headers
+     * @param ignoredHeaders headers that should be deleted, if empty all will be deleted
+     */
+    public void execute(String filterType,
+                        Boolean deleteBody,
+                        Boolean deleteUri,
+                        Boolean headers,
+                        List<String> ignoredHeaders) {
+
+        RequestResponseParser requestResponseParser = null;
+
+        switch (filterType) {
+            case PRE_TYPE:
+                requestResponseParser = TraceContextHolder.getInstance().getActualTrace().getRequest();
+                break;
+
+            case POST_TYPE:
+                requestResponseParser = TraceContextHolder.getInstance().getActualTrace().getResponse();
+                break;
+
+            default:
+                break;
+        }
+
+        if (requestResponseParser != null) {
+
+            // Should delete body
+            if (deleteBody) requestResponseParser.setBody(null);
+
+            // Should delete URI
+            if (deleteUri) requestResponseParser.setUri(null);
+
+            // Should delete headers
+            if (headers) {
+                if (ignoredHeaders.isEmpty()) {
+                    requestResponseParser.setHeaders(null);
+                } else {
+                    final Map<String, String> requestResponseHeaders = requestResponseParser.getHeaders();
+                    ignoredHeaders.forEach(requestResponseHeaders::remove);
+                }
+            }
+        }
+    }
+}

--- a/heimdall-gateway/src/main/resources/template-interceptor/log_masker.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/log_masker.mustache
@@ -1,0 +1,79 @@
+import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
+import br.com.conductor.heimdall.core.util.BeanManager;
+import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.LogMaskerService;
+import br.com.conductor.heimdall.gateway.trace.RequestResponseParser;
+import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
+import com.netflix.zuul.context.RequestContext;
+
+import java.util.*;
+
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
+
+public class LogIgnoreInterceptor extends HeimdallFilter {
+
+    private static Set<String> pathsAllowed;
+
+    private static Set<String> pathsNotAllowed;
+
+    private static String inboundURL;
+
+    private static String method;
+
+    private static Long referenceId;
+
+    public LogIgnoreInterceptor() {
+
+        method = "{{method}}";
+
+        pathsAllowed = new HashSet<>();
+        {{#pathsAllowed}}
+        pathsAllowed.add("{{.}}");
+        {{/pathsAllowed}}
+
+        pathsNotAllowed = new HashSet<>();
+        {{#pathsNotAllowed}}
+        pathsNotAllowed.add("{{.}}");
+        {{/pathsNotAllowed }}
+
+        inboundURL = "{{inboundURL}}";
+
+        referenceId = {{referenceId}};
+
+    }
+
+    @Override
+    public String filterType() {
+        return "{{executionPoint}}";
+    }
+
+    @Override
+    public int filterOrder() {
+        return {{order}};
+    }
+
+    @Override
+    public String getName() {
+        return "{{name}}";
+    }
+
+    @Override
+    public boolean should() {
+        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
+        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+    }
+
+    @Override
+    public void execute() throws Throwable {
+
+        List<String> ignoredHeaders = new ArrayList<>();
+        {{#ignoredHeaders}}
+        ignoredHeaders.add("{{.}}");
+        {{/ignoredHeaders}}
+        LogMaskerService logMaskerService = (LogMaskerService) BeanManager.getBean(LogMaskerService.class);
+
+        logMaskerService.execute(filterType(), {{body}}, {{uri}}, {{headers}}, ignoredHeaders);
+    }
+}

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/service/LogMaskerServiceTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/service/LogMaskerServiceTest.java
@@ -1,0 +1,241 @@
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
+package br.com.conductor.heimdall.gateway.service;
+
+import br.com.conductor.heimdall.gateway.trace.RequestResponseParser;
+import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LogMaskerServiceTest {
+
+    @InjectMocks
+    private LogMaskerService logMaskerService;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        TraceContextHolder.getInstance().init(true, "developer", new MockHttpServletRequest(), false);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("connection", "Keep-alive");
+        headers.put("host", "http://another-host.com");
+        headers.put("Content-Type", "application/json;utf-8");
+        headers.put("simpleHeader", "someInformation");
+
+        String body = "{\"body\":\"this is a simple body\"}";
+        String uri = "http://simpleUri.com";
+
+        RequestResponseParser request = new RequestResponseParser();
+        RequestResponseParser response = new RequestResponseParser();
+
+        request.setHeaders(headers);
+        request.setUri(uri);
+        request.setBody(body);
+
+        response.setHeaders(headers);
+        response.setUri(uri);
+        response.setBody(body);
+
+        TraceContextHolder.getInstance().getActualTrace().setRequest(request);
+        TraceContextHolder.getInstance().getActualTrace().setResponse(response);
+    }
+
+    @After
+    public void after() {
+        TraceContextHolder.getInstance().unset();
+    }
+
+    @Test
+    public void requestDeleteAll() {
+
+        logMaskerService.execute(PRE_TYPE, true, true, true, new ArrayList<>());
+
+        RequestResponseParser request = TraceContextHolder.getInstance().getActualTrace().getRequest();
+
+        assertNull(request.getBody());
+        assertNull(request.getUri());
+        assertNull(request.getHeaders());
+    }
+
+    @Test
+    public void requestDeleteBody() {
+
+        logMaskerService.execute(PRE_TYPE, true, false, false, new ArrayList<>());
+
+        RequestResponseParser request = TraceContextHolder.getInstance().getActualTrace().getRequest();
+
+        assertNull(request.getBody());
+        assertNotNull(request.getUri());
+        assertNotNull(request.getHeaders());
+    }
+
+    @Test
+    public void requestDeleteUri() {
+
+        logMaskerService.execute(PRE_TYPE, false, true, false, new ArrayList<>());
+
+        RequestResponseParser request = TraceContextHolder.getInstance().getActualTrace().getRequest();
+
+        assertNotNull(request.getBody());
+        assertNull(request.getUri());
+        assertNotNull(request.getHeaders());
+    }
+
+    @Test
+    public void requestDeleteAllHeaders() {
+
+        logMaskerService.execute(PRE_TYPE, false, false, true, new ArrayList<>());
+
+        RequestResponseParser request = TraceContextHolder.getInstance().getActualTrace().getRequest();
+
+        assertNotNull(request.getBody());
+        assertNotNull(request.getUri());
+        assertNull(request.getHeaders());
+    }
+
+    @Test
+    public void requestDeleteSomeHeaders() {
+
+        List<String> ignoredHeaders = Arrays.asList("simpleHeader", "host");
+
+        logMaskerService.execute(PRE_TYPE, false, false, true, ignoredHeaders);
+
+        RequestResponseParser request = TraceContextHolder.getInstance().getActualTrace().getRequest();
+
+        assertNotNull(request.getBody());
+        assertNotNull(request.getUri());
+        assertNotNull(request.getHeaders());
+        assertNull(request.getHeaders().get("simpleHeader"));
+        assertNull(request.getHeaders().get("host"));
+    }
+
+    @Test
+    public void requestDeleteAbsentHeaders() {
+
+        List<String> ignoredHeaders = Arrays.asList("simpleHeader", "host", "someOtherHeader");
+
+        logMaskerService.execute(PRE_TYPE, false, false, true, ignoredHeaders);
+
+        RequestResponseParser request = TraceContextHolder.getInstance().getActualTrace().getRequest();
+
+        assertNotNull(request.getBody());
+        assertNotNull(request.getUri());
+        assertNotNull(request.getHeaders());
+        assertNull(request.getHeaders().get("simpleHeader"));
+        assertNull(request.getHeaders().get("host"));
+        assertNull(request.getHeaders().get("someOtherHeader"));
+    }
+
+    @Test
+    public void responseDeleteAll() {
+
+        logMaskerService.execute(POST_TYPE, true, true, true, new ArrayList<>());
+
+        RequestResponseParser response = TraceContextHolder.getInstance().getActualTrace().getResponse();
+
+        assertNull(response.getBody());
+        assertNull(response.getUri());
+        assertNull(response.getHeaders());
+    }
+
+    @Test
+    public void responseDeleteBody() {
+
+        logMaskerService.execute(POST_TYPE, true, false, false, new ArrayList<>());
+
+        RequestResponseParser response = TraceContextHolder.getInstance().getActualTrace().getResponse();
+
+        assertNull(response.getBody());
+        assertNotNull(response.getUri());
+        assertNotNull(response.getHeaders());
+    }
+
+    @Test
+    public void responseDeleteUri() {
+
+        logMaskerService.execute(POST_TYPE, false, true, false, new ArrayList<>());
+
+        RequestResponseParser response = TraceContextHolder.getInstance().getActualTrace().getResponse();
+
+        assertNotNull(response.getBody());
+        assertNull(response.getUri());
+        assertNotNull(response.getHeaders());
+    }
+
+    @Test
+    public void responseDeleteAllHeaders() {
+
+        logMaskerService.execute(POST_TYPE, false, false, true, new ArrayList<>());
+
+        RequestResponseParser response = TraceContextHolder.getInstance().getActualTrace().getResponse();
+
+        assertNotNull(response.getBody());
+        assertNotNull(response.getUri());
+        assertNull(response.getHeaders());
+    }
+
+    @Test
+    public void responseDeleteSomeHeaders() {
+
+        List<String> ignoredHeaders = Arrays.asList("simpleHeader", "host");
+
+        logMaskerService.execute(POST_TYPE, false, false, true, ignoredHeaders);
+
+        RequestResponseParser response = TraceContextHolder.getInstance().getActualTrace().getResponse();
+
+        assertNotNull(response.getBody());
+        assertNotNull(response.getUri());
+        assertNotNull(response.getHeaders());
+        assertNull(response.getHeaders().get("simpleHeader"));
+        assertNull(response.getHeaders().get("host"));
+    }
+
+    @Test
+    public void responseDeleteAbsentHeaders() {
+
+        List<String> ignoredHeaders = Arrays.asList("simpleHeader", "host", "someOtherHeader");
+
+        logMaskerService.execute(POST_TYPE, false, false, true, ignoredHeaders);
+
+        RequestResponseParser response = TraceContextHolder.getInstance().getActualTrace().getResponse();
+
+        assertNotNull(response.getBody());
+        assertNotNull(response.getUri());
+        assertNotNull(response.getHeaders());
+        assertNull(response.getHeaders().get("simpleHeader"));
+        assertNull(response.getHeaders().get("host"));
+        assertNull(response.getHeaders().get("someOtherHeader"));
+    }
+}


### PR DESCRIPTION
Since the PR #130 the log interceptor is now a built in filter and its executed for all requests and writes the body, headers and uri to the request and response objects in the trace.

This new interceptor adds a new option to mask the logs, that way the user can chose to remove the body, the uri or any of the headers, or all, from the trace information.

Usage, examples with the interceptor content:
* Delete the body from the request
```json
{
  "body": true
}
```
* Delete the body and two headers
```json
{
  "body": true,
  "headers": true,
  "ignoredHeaders": [
    "someHeader", "anotherHeader"
  ]
}
```
* Delete the uri and all header but not the body
```json
{
  "uri": true,
  "headers": true
}
```
