### PR TITLE
Interceptor Services

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/CacheInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/CacheInterceptorService.java
@@ -22,6 +22,7 @@ package br.com.conductor.heimdall.gateway.service;
  */
 
 import br.com.conductor.heimdall.core.util.BeanManager;
+import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
 import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Helper;
 import com.netflix.zuul.context.RequestContext;
@@ -52,11 +53,12 @@ public class CacheInterceptorService {
      *
      * @param cacheName   Cache name provided
      * @param timeToLive  How much time the cache will live (0 or less to live forever)
-     * @param helper      {@link Helper}
      * @param headers     List of headers that when present signal that the request should be cached
      * @param queryParams List of queryParams that when present signal that the request should be cached
      */
-    public void cacheInterceptor(String cacheName, Long timeToLive, Helper helper, List<String> headers, List<String> queryParams) {
+    public void cacheInterceptor(String cacheName, Long timeToLive, List<String> headers, List<String> queryParams) {
+
+        Helper helper = new HelperImpl();
 
         RedissonClient redisson = (RedissonClient) BeanManager.getBean(RedissonClient.class);
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IdentifierInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IdentifierInterceptorService.java
@@ -1,0 +1,19 @@
+package br.com.conductor.heimdall.gateway.service;
+
+import com.netflix.zuul.context.RequestContext;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+import static br.com.conductor.heimdall.core.util.ConstantsInterceptors.IDENTIFIER_ID;
+
+@Service
+public class IdentifierInterceptorService {
+
+    public void execute() {
+        String uid = UUID.randomUUID().toString();
+
+        RequestContext context = RequestContext.getCurrentContext();
+        context.addZuulRequestHeader(IDENTIFIER_ID, uid);
+    }
+}

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IdentifierInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IdentifierInterceptorService.java
@@ -1,3 +1,22 @@
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
 package br.com.conductor.heimdall.gateway.service;
 
 import com.netflix.zuul.context.RequestContext;
@@ -7,9 +26,17 @@ import java.util.UUID;
 
 import static br.com.conductor.heimdall.core.util.ConstantsInterceptors.IDENTIFIER_ID;
 
+/**
+ * Identifier interceptor adds a unique ID to the request headers
+ *
+ * @author Marcelo Aguiar Rodrigues
+ */
 @Service
 public class IdentifierInterceptorService {
 
+    /**
+     * Adds a unique ID to the request headers
+     */
     public void execute() {
         String uid = UUID.randomUUID().toString();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/InterceptorFileService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/InterceptorFileService.java
@@ -1,6 +1,3 @@
-
-package br.com.conductor.heimdall.gateway.service;
-
 /*-
  * =========================LICENSE_START==================================
  * heimdall-gateway
@@ -20,6 +17,7 @@ package br.com.conductor.heimdall.gateway.service;
  * limitations under the License.
  * ==========================LICENSE_END===================================
  */
+package br.com.conductor.heimdall.gateway.service;
 
 import br.com.conductor.heimdall.core.dto.InterceptorFileDTO;
 import br.com.conductor.heimdall.core.dto.interceptor.AccessTokenClientIdDTO;
@@ -144,8 +142,8 @@ public class InterceptorFileService {
         } else {
 
             String[] message = {ExceptionMessage.INTERCEPTOR_TEMPLATE_NOT_EXIST.getMessage(), interceptor.getId().toString(), interceptor.getType().name(), interceptor.getExecutionPoint().name()};
-            String erro = StringUtils.join(", ", message);
-            log.error(erro);
+            String error = StringUtils.join(", ", message);
+            log.error(error);
 
             return null;
         }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IpsInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IpsInterceptorService.java
@@ -20,6 +20,8 @@ package br.com.conductor.heimdall.gateway.service;
  * ==========================LICENSE_END===================================
  */
 
+import com.netflix.zuul.context.RequestContext;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
@@ -37,6 +39,24 @@ import java.util.Set;
 public class IpsInterceptorService {
 
     private final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
+
+    public void executeWhiteList(Set<String> whitelist) throws Throwable {
+
+        RequestContext ctx = RequestContext.getCurrentContext();
+
+        if (!verifyIpInList(ctx.getRequest(), whitelist)){
+            ctx.getResponse().sendError(HttpStatus.UNAUTHORIZED.value(), "IP unauthorized");
+        }
+    }
+
+    public void executeBlackList(Set<String> blacklist) throws Throwable {
+
+        RequestContext ctx = RequestContext.getCurrentContext();
+
+        if (verifyIpInList(ctx.getRequest(), blacklist)){
+            ctx.getResponse().sendError(HttpStatus.UNAUTHORIZED.value(), "IP unauthorized");
+        }
+    }
 
     /**
      * Method that verifies if Ips from the interceptor Blacklist or Whitelist contains any IP from request

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IpsInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/IpsInterceptorService.java
@@ -34,12 +34,17 @@ import java.util.Set;
  * Provides methods to validate request with blacklist and whitelist interceptors.
  *
  * @author <a href="https://dijalmasilva.github.io" target="_blank">Dijalma Silva</a>
+ * @author Marcelo Aguiar Rodrigues
  */
 @Service
 public class IpsInterceptorService {
 
-    private final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
-
+    /**
+     * Checks if the request ip is in the whitelist
+     *
+     * @param whitelist Set of allowed ids
+     * @throws Throwable
+     */
     public void executeWhiteList(Set<String> whitelist) throws Throwable {
 
         RequestContext ctx = RequestContext.getCurrentContext();
@@ -49,6 +54,12 @@ public class IpsInterceptorService {
         }
     }
 
+    /**
+     * Checks if the request ip is in the blacklist
+     *
+     * @param blacklist Set of blocked ids
+     * @throws Throwable
+     */
     public void executeBlackList(Set<String> blacklist) throws Throwable {
 
         RequestContext ctx = RequestContext.getCurrentContext();
@@ -63,7 +74,7 @@ public class IpsInterceptorService {
      *
      * @param req {@link HttpServletRequest}
      * @param ips {@link Set}<{@link String}>
-     * @return True if contains or false otherwise
+     * @return True if contains, false otherwise
      */
     public boolean verifyIpInList(HttpServletRequest req, Set<String> ips) {
         Set<String> ipsFromRequest = getIpFromRequest(req);
@@ -82,13 +93,14 @@ public class IpsInterceptorService {
 
         if (Objects.nonNull(req)) {
 
-            if (Objects.nonNull(req.getHeader(X_FORWARDED_FOR))){
-                Arrays.stream(req.getHeader(X_FORWARDED_FOR).split(","))
+            final String x_FORWARDED_FOR = "X-FORWARDED-FOR";
+
+            if (Objects.nonNull(req.getHeader(x_FORWARDED_FOR))){
+                Arrays.stream(req.getHeader(x_FORWARDED_FOR).split(","))
                         .forEach(ip -> ipsFromRequest.add(ip.trim()));
             }
 
             ipsFromRequest.add(req.getRemoteAddr());
-
         }
 
         return ipsFromRequest;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/MockInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/MockInterceptorService.java
@@ -1,0 +1,37 @@
+package br.com.conductor.heimdall.gateway.service;
+
+import br.com.conductor.heimdall.core.util.ConstantsInterceptors;
+import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
+import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
+import br.com.conductor.heimdall.middleware.spec.Helper;
+import com.netflix.zuul.context.RequestContext;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MockInterceptorService {
+
+    public void execute(Integer status, String body) {
+
+        Helper helper = new HelperImpl();
+        RequestContext ctx = RequestContext.getCurrentContext();
+
+        String response;
+        if (helper.json().isJson(body)) {
+            response = helper.json().parse(body);
+
+            helper.call().response().header().add("Content-Type", "application/json");
+        } else {
+
+            response = body;
+
+            helper.call().response().header().add("Content-Type", "text/plain");
+        }
+
+        helper.call().response().setBody(response);
+
+        ctx.setSendZuulResponse(false);
+        ctx.setResponseStatusCode(status);
+
+        TraceContextHolder.getInstance().getActualTrace().trace(ConstantsInterceptors.GLOBAL_MOCK_INTERCEPTOR_LOCALIZED, response);
+    }
+}

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/MockInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/MockInterceptorService.java
@@ -1,3 +1,22 @@
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
 package br.com.conductor.heimdall.gateway.service;
 
 import br.com.conductor.heimdall.core.util.ConstantsInterceptors;
@@ -7,9 +26,20 @@ import br.com.conductor.heimdall.middleware.spec.Helper;
 import com.netflix.zuul.context.RequestContext;
 import org.springframework.stereotype.Service;
 
+/**
+ * Mock Interceptor service provides a simple response to show the user.
+ *
+ * @author Marcelo Aguiar Rodrigues
+ */
 @Service
 public class MockInterceptorService {
 
+    /**
+     * Creates a response to the user with the body content.
+     *
+     * @param status HttpStatus to be sent back
+     * @param body   Response body
+     */
     public void execute(Integer status, String body) {
 
         Helper helper = new HelperImpl();

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -72,6 +72,29 @@ public class OAuthInterceptorService {
 
     private Helper helper;
 
+    public void execute(TypeOAuth typeOAuth, String privateKey, int timeAccessToken, int timeRefreshToken, Long providerId, Helper helper) {
+
+        try {
+            executeInterceptor(typeOAuth, privateKey, timeAccessToken, timeRefreshToken, providerId, helper);
+        } catch( HeimdallException ex ){
+            generateResponse( ex.getMsgEnum().getMessage(), ex.getMsgEnum().getHttpCode());
+        }
+    }
+
+    /**
+     * Method that sends a Response
+     *
+     * @param message    Response message
+     * @param httpStatus {@link HttpStatus} of the response
+     */
+    private void generateResponse(String message, int httpStatus) {
+        message = "{ \"error\" : \"" + message + "\" }";
+        TraceContextHolder.getInstance().getActualTrace().trace(message);
+        this.helper.call().response().setStatus(httpStatus);
+        this.helper.call().response().header().add("Content-Type", "application/json");
+        this.helper.call().response().setBody(message);
+    }
+
     /**
      * Method to validate Interceptor OAuth and execute the operation correct, accord the type of the OAuth.
      *

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -72,6 +72,16 @@ public class OAuthInterceptorService {
 
     private Helper helper;
 
+    /**
+     * Runs the service for the OAuth
+     *
+     * @param typeOAuth        type of the OAuth
+     * @param privateKey       privateKey used in Token
+     * @param timeAccessToken  time to expire accessToken
+     * @param timeRefreshToken time to expire refreshToken
+     * @param providerId       {@link Provider} id
+     * @param helper           {@link Helper}
+     */
     public void execute(TypeOAuth typeOAuth, String privateKey, int timeAccessToken, int timeRefreshToken, Long providerId, Helper helper) {
 
         try {

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -1,5 +1,3 @@
-package br.com.conductor.heimdall.gateway.service;
-
 /*-
  * =========================LICENSE_START==================================
  * heimdall-gateway
@@ -19,6 +17,7 @@ package br.com.conductor.heimdall.gateway.service;
  * limitations under the License.
  * ==========================LICENSE_END===================================
  */
+package br.com.conductor.heimdall.gateway.service;
 
 import static br.com.conductor.heimdall.core.util.ConstantsOAuth.*;
 import br.com.conductor.heimdall.core.dto.request.OAuthRequest;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/RattingInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/RattingInterceptorService.java
@@ -1,0 +1,62 @@
+package br.com.conductor.heimdall.gateway.service;
+
+import br.com.conductor.heimdall.core.entity.RateLimit;
+import br.com.conductor.heimdall.core.enums.Interval;
+import br.com.conductor.heimdall.core.repository.RateLimitRepository;
+import br.com.conductor.heimdall.core.util.BeanManager;
+import com.netflix.zuul.context.RequestContext;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+public class RattingInterceptorService {
+
+    public void execute(String name, String path) {
+        RateLimitRepository repository = (RateLimitRepository) BeanManager.getBean(RateLimitRepository.class);
+        RedissonClient redisson = (RedissonClient) BeanManager.getBean(RedissonClient.class);
+        RequestContext ctx = RequestContext.getCurrentContext();
+
+        RLock lock = redisson.getLock(name);
+        lock.lock();
+
+        RateLimit rate = repository.find(path);
+        if (rate.getLastRequest() == null) {
+            rate.setLastRequest(LocalDateTime.now());
+        }
+
+
+        if (isIntervalEnded(rate)) {
+            rate.reset();
+            rate.decreaseRemaining();
+            repository.save(rate);
+        } else {
+            if (rate.hasRemaining()) {
+                rate.decreaseRemaining();
+                repository.save(rate);
+            } else {
+                ctx.setSendZuulResponse(false);
+                ctx.setResponseStatusCode(HttpStatus.TOO_MANY_REQUESTS.value());
+                ctx.setResponseBody(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase());
+            }
+
+        }
+        lock.unlock();
+    }
+
+    private boolean isIntervalEnded(RateLimit rate) {
+
+        if (rate.getInterval() == Interval.SECONDS) {
+            return Duration.between(LocalDateTime.now(), rate.getLastRequest()).getSeconds() != 0;
+        } else if (rate.getInterval() == Interval.MINUTES) {
+            return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toMinutes() != 0;
+        } else {
+            return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toHours() != 0;
+        }
+    }
+
+}

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/RattingInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/RattingInterceptorService.java
@@ -1,3 +1,22 @@
+/*-
+ * =========================LICENSE_START==================================
+ * heimdall-gateway
+ * ========================================================================
+ * Copyright (C) 2018 Conductor Tecnologia SA
+ * ========================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================LICENSE_END===================================
+ */
 package br.com.conductor.heimdall.gateway.service;
 
 import br.com.conductor.heimdall.core.entity.RateLimit;
@@ -13,9 +32,20 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+/**
+ * Rate limit interceptor provides a limit to the number of requests
+ *
+ * @author Marcelo Aguiar Rodrigues
+ */
 @Service
 public class RattingInterceptorService {
 
+    /**
+     * Limits the number of requests to a specific path
+     *
+     * @param name RLock name
+     * @param path rate limit key
+     */
     public void execute(String name, String path) {
         RateLimitRepository repository = (RateLimitRepository) BeanManager.getBean(RateLimitRepository.class);
         RedissonClient redisson = (RedissonClient) BeanManager.getBean(RedissonClient.class);
@@ -29,8 +59,7 @@ public class RattingInterceptorService {
             rate.setLastRequest(LocalDateTime.now());
         }
 
-
-        if (isIntervalEnded(rate)) {
+        if (hasIntervalEnded(rate)) {
             rate.reset();
             rate.decreaseRemaining();
             repository.save(rate);
@@ -48,7 +77,10 @@ public class RattingInterceptorService {
         lock.unlock();
     }
 
-    private boolean isIntervalEnded(RateLimit rate) {
+    /*
+     * Checks if the limiting time has ended
+     */
+    private boolean hasIntervalEnded(RateLimit rate) {
 
         if (rate.getInterval() == Interval.SECONDS) {
             return Duration.between(LocalDateTime.now(), rate.getLastRequest()).getSeconds() != 0;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/RattingInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/RattingInterceptorService.java
@@ -20,7 +20,6 @@
 package br.com.conductor.heimdall.gateway.service;
 
 import br.com.conductor.heimdall.core.entity.RateLimit;
-import br.com.conductor.heimdall.core.enums.Interval;
 import br.com.conductor.heimdall.core.repository.RateLimitRepository;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import com.netflix.zuul.context.RequestContext;
@@ -80,14 +79,20 @@ public class RattingInterceptorService {
     /*
      * Checks if the limiting time has ended
      */
-    private boolean hasIntervalEnded(RateLimit rate) {
+    public boolean hasIntervalEnded(RateLimit rate) {
 
-        if (rate.getInterval() == Interval.SECONDS) {
-            return Duration.between(LocalDateTime.now(), rate.getLastRequest()).getSeconds() != 0;
-        } else if (rate.getInterval() == Interval.MINUTES) {
-            return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toMinutes() != 0;
-        } else {
-            return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toHours() != 0;
+        switch (rate.getInterval()) {
+            case SECONDS:
+                return Duration.between(LocalDateTime.now(), rate.getLastRequest()).getSeconds() > 0;
+
+            case MINUTES:
+                return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toMinutes() > 0;
+
+            case HOURS:
+                return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toHours() > 0;
+
+            default:
+                return false;
         }
     }
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/SecurityService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/SecurityService.java
@@ -1,6 +1,3 @@
-
-package br.com.conductor.heimdall.gateway.service;
-
 /*-
  * =========================LICENSE_START==================================
  * heimdall-gateway
@@ -20,6 +17,7 @@ package br.com.conductor.heimdall.gateway.service;
  * limitations under the License.
  * ==========================LICENSE_END===================================
  */
+package br.com.conductor.heimdall.gateway.service;
 
 import br.com.conductor.heimdall.core.entity.AccessToken;
 import br.com.conductor.heimdall.core.entity.App;
@@ -48,40 +46,40 @@ import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
  */
 @Service
 public class SecurityService {
-     
+
      @Autowired
      private AccessTokenRepository accessTokenRepository;
 
      @Autowired
      private AppRepository appRepository;
-     
+
      /**
       * Method responsible for validating access_token in interceptor
-      * 
-      * @param ctx 
-      * @param apiId
-      * @param clientId
-      * @param accessToken
+      *
+      * @param ctx         RequestContext
+      * @param apiId       Api reference id
+      * @param clientId    user client_id
+      * @param accessToken access token
       */
      public void validadeAccessToken(RequestContext ctx, Long apiId, String clientId, String accessToken) {
-                    
+
           final String ACCESS_TOKEN = "Access Token";
-          
+
           TraceContextHolder.getInstance().getActualTrace().setAccessToken(DigestUtils.digestMD5(accessToken));
-          
+
           if (Objeto.notBlank(accessToken) && Objeto.notBlank(clientId)) {
-                    
-               AccessToken token = accessTokenRepository.findAccessTokenActive(accessToken);               
+
+               AccessToken token = accessTokenRepository.findAccessTokenActive(accessToken);
                if (Objeto.notBlank(token)) {
-                    
+
                     List<Plan> plans = token.getApp().getPlans();
                     Plan plan = plans.stream().filter(p -> apiId.equals(p.getApi().getId())).findFirst().orElse(null);
                     if (Objeto.notBlank(plan)) {
-                         
+
                          String cId = token.getApp().getClientId();
-                         
+
                          if (Objeto.notBlank(cId) && clientId.equals(cId)) {
-                              
+
                               TraceContextHolder.getInstance().getActualTrace().setApp(token.getApp().getName());
                          } else {
 
@@ -101,7 +99,7 @@ public class SecurityService {
                buildResponse(ctx, String.format(ConstantsInterceptors.GLOBAL_CLIENT_ID_OR_ACESS_TOKEN_NOT_FOUND, ACCESS_TOKEN));
           }
      }
-     
+
      /**
       * Method responsible for validating client_id in interceptor
       *
@@ -112,9 +110,9 @@ public class SecurityService {
      public void validateClientId(RequestContext ctx, Long apiId, String clientId) {
 
           final String CLIENT_ID = "Client Id";
-          
+
           if (Objects.nonNull(clientId)) {
-               
+
                TraceContextHolder.getInstance().getActualTrace().setClientId(DigestUtils.digestMD5(clientId));
                App app = appRepository.findByClientId(clientId);
                if (Objects.isNull(app)) {

--- a/heimdall-gateway/src/main/resources/template-interceptor/blacklist_ip.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/blacklist_ip.mustache
@@ -1,94 +1,80 @@
-import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
-
-import java.util.*;
-
-import com.netflix.zuul.ZuulFilter;
-import com.google.common.collect.Sets;
-import com.netflix.zuul.context.RequestContext;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
-import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
-import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
-import br.com.conductor.heimdall.middleware.spec.*;
 import br.com.conductor.heimdall.core.util.BeanManager;
+import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.service.IpsInterceptorService;
-import org.springframework.http.HttpStatus;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+
+import com.netflix.zuul.context.RequestContext;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class BlacklistInterceptor extends HeimdallFilter {
 
-     private static Set<String> pathsAllowed;
+    private static Set<String> pathsAllowed;
 
-     private static Set<String> pathsNotAllowed;
+    private static Set<String> pathsNotAllowed;
 
-     private static Set<String> blacklist;
+    private static Set<String> blacklist;
 
-     private static String inboundURL;
+    private static String inboundURL;
 
-     private static String method;
+    private static String method;
 
-     private static Long referenceId;
+    private static Long referenceId;
 
-     private IpsInterceptorService ipsInterceptorService;
+    public BlacklistInterceptor() {
 
-     public BlacklistInterceptor() {
+        pathsAllowed = new HashSet<>();
+        {{#pathsAllowed}}
+        pathsAllowed.add("{{.}}");
+        {{/pathsAllowed}}
 
-          pathsAllowed = Sets.newHashSet(); {{#pathsAllowed}}
-          pathsAllowed.add("{{.}}");     {{/pathsAllowed}}
+        pathsNotAllowed = new HashSet<>();
+        {{#pathsNotAllowed}}
+        pathsNotAllowed.add("{{.}}");
+        {{/pathsNotAllowed}}
 
-          pathsNotAllowed = Sets.newHashSet();     {{#pathsNotAllowed}}
-          pathsNotAllowed.add("{{.}}");     {{/pathsNotAllowed}}
+        blacklist = new HashSet<>();
+        {{#ips}}
+        blacklist.add("{{.}}");
+        {{/ips}}
 
-          blacklist = Sets.newHashSet();   {{#ips}}
-          blacklist.add("{{.}}");      {{/ips}}
+        inboundURL = "{{inboundURL}}";
 
-          inboundURL = "{{inboundURL}}";
-          method = "{{method}}";
+        method = "{{method}}";
 
-          referenceId = {{referenceId}};
+        referenceId = {{referenceId}};
+    }
 
-     }
+    @Override
+    public int filterOrder() {
 
-     @Override
-     public int filterOrder() {
+        return {{order}};
+    }
 
-          return {{order}};
-     }
+    @Override
+    public String filterType() {
 
-     @Override
-     public String filterType() {
+        return "{{executionPoint}}";
+    }
 
-          return "{{executionPoint}}";
-     }
+    @Override
+    public String getName() {
+        return "{{name}}";
+    }
 
-     @Override
-     public boolean should() {
+    @Override
+    public boolean should() {
 
-          LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
-          return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-     }
+        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
+        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+    }
 
-     @Override
-     public String getName() {
-     	return "{{name}}";
-     }
+    @Override
+    public void execute() throws Throwable {
 
-     @Override
-     public void execute() throws Throwable {
-
-            try {
-
-                RequestContext ctx = RequestContext.getCurrentContext();
-
-                ipsInterceptorService = (IpsInterceptorService) BeanManager.getBean(IpsInterceptorService.class);
-
-                if (ipsInterceptorService.verifyIpInList(ctx.getRequest(), blacklist)){
-                    ctx.getResponse().sendError(HttpStatus.UNAUTHORIZED.value(), "IP unauthorized");
-                }
-            } catch (IOException e) {
-                TraceContextHolder.getInstance().getActualTrace().trace(e.getMessage());
-            } finally {
-                return null;
-            }
-
-     }
+        IpsInterceptorService ipsInterceptorService = (IpsInterceptorService) BeanManager.getBean(IpsInterceptorService.class);
+        ipsInterceptorService.executeBlackList(blacklist);
+    }
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/cache.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/cache.mustache
@@ -1,19 +1,17 @@
-import java.util.*;
-
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.util.BeanManager;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
-import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.service.CacheInterceptorService;
-import br.com.conductor.heimdall.middleware.spec.Helper;
 
-import com.google.common.collect.Sets;
-import com.google.common.collect.Lists;
 import com.netflix.zuul.context.RequestContext;
 
-import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
 
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
 
 public class CacheInterceptor extends HeimdallFilter {
 
@@ -33,11 +31,7 @@ public class CacheInterceptor extends HeimdallFilter {
 
     private static List<String> queryParams;
 
-    private CacheInterceptorService cacheInterceptorService;
-
     private static Long timeToLive;
-
-    private Helper helper;
 
     public CacheInterceptor() {
 
@@ -47,46 +41,29 @@ public class CacheInterceptor extends HeimdallFilter {
 
         method = "{{method}}";
 
-        headers = Lists.newArrayList();
+        headers = new ArrayList<>();
         {{#headers}}
         headers.add("{{.}}");
         {{/headers}}
 
-        queryParams = Lists.newArrayList();
+        queryParams = new ArrayList<>();
         {{#queryParams}}
         queryParams.add("{{.}}");
         {{/queryParams}}
 
-        pathsAllowed = Sets.newHashSet();
+        pathsAllowed = new HashSet<>();
         {{#pathsAllowed}}
         pathsAllowed.add("{{.}}");
         {{/pathsAllowed}}
 
-        pathsNotAllowed = Sets.newHashSet();
+        pathsNotAllowed = new HashSet<>();
         {{#pathsNotAllowed}}
         pathsNotAllowed.add("{{.}}");
         {{/pathsNotAllowed}}
 
         inboundURL = "{{inboundURL}}";
 
-        this.helper = new HelperImpl();
-
         referenceId = {{referenceId}};
-
-    }
-
-    @Override
-    public boolean should() {
-        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
-        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-    }
-
-    @Override
-    public void execute() throws Throwable {
-
-        cacheInterceptorService = (CacheInterceptorService) BeanManager.getBean(CacheInterceptorService.class);
-
-        cacheInterceptorService.cacheInterceptor(cacheName, timeToLive, helper, headers, queryParams);
     }
 
     @Override
@@ -102,5 +79,19 @@ public class CacheInterceptor extends HeimdallFilter {
     @Override
     public int filterOrder() {
         return {{order}};
+    }
+
+    @Override
+    public boolean should() {
+
+        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
+        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+    }
+
+    @Override
+    public void execute() throws Throwable {
+
+        CacheInterceptorService cacheInterceptorService = (CacheInterceptorService) BeanManager.getBean(CacheInterceptorService.class);
+        cacheInterceptorService.cacheInterceptor(cacheName, timeToLive, headers, queryParams);
     }
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/cache_clear.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/cache_clear.mustache
@@ -1,17 +1,19 @@
-import java.util.*;
-
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.core.util.Constants;
 import br.com.conductor.heimdall.gateway.service.CacheInterceptorService;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.trace.FilterDetail;
+import br.com.conductor.heimdall.gateway.trace.StackTraceImpl;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
 
-import com.google.common.collect.Sets;
-import com.google.common.collect.Lists;
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.ZuulFilter;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
 
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
 
@@ -29,8 +31,6 @@ public class CacheClearInterceptor extends ZuulFilter {
 
     private static Long referenceId;
 
-    private CacheInterceptorService cacheInterceptorService;
-
     private FilterDetail detail;
 
     public CacheClearInterceptor() {
@@ -39,12 +39,12 @@ public class CacheClearInterceptor extends ZuulFilter {
 
         method = "{{method}}";
 
-        pathsAllowed = Sets.newHashSet();
+        pathsAllowed = new HashSet<>();
         {{#pathsAllowed}}
         pathsAllowed.add("{{.}}");
         {{/pathsAllowed}}
 
-        pathsNotAllowed = Sets.newHashSet();
+        pathsNotAllowed = new HashSet<>();
         {{#pathsNotAllowed}}
         pathsNotAllowed.add("{{.}}");
         {{/pathsNotAllowed}}
@@ -54,7 +54,16 @@ public class CacheClearInterceptor extends ZuulFilter {
         detail = new FilterDetail();
 
         referenceId = {{referenceId}};
+    }
 
+    @Override
+    public String filterType() {
+        return POST_TYPE;
+    }
+
+    @Override
+    public int filterOrder() {
+        return {{order}};
     }
 
     @Override
@@ -71,7 +80,7 @@ public class CacheClearInterceptor extends ZuulFilter {
             detail.setStatus(Constants.SUCCESS);
         } catch (Exception e) {
             detail.setStatus(Constants.FAILED);
-            throw e;
+            detail.setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), ExceptionUtils.getStackTrace(e)));
         } finally {
             long endTime = System.currentTimeMillis();
 
@@ -86,19 +95,8 @@ public class CacheClearInterceptor extends ZuulFilter {
     }
 
     private void process() {
-        cacheInterceptorService = (CacheInterceptorService) BeanManager.getBean(CacheInterceptorService.class);
 
+        CacheInterceptorService cacheInterceptorService = (CacheInterceptorService) BeanManager.getBean(CacheInterceptorService.class);
         cacheInterceptorService.cacheClearInterceptor(cacheName);
-        return null;
-    }
-
-    @Override
-    public String filterType() {
-        return POST_TYPE;
-    }
-
-    @Override
-    public int filterOrder() {
-        return {{order}};
     }
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/identifier.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/identifier.mustache
@@ -1,15 +1,13 @@
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
-import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
-import br.com.conductor.heimdall.middleware.spec.Helper;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.IdentifierInterceptorService;
+
 import com.netflix.zuul.context.RequestContext;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
-
-import static br.com.conductor.heimdall.core.util.ConstantsInterceptors.IDENTIFIER_ID;
 
 public class UniqueID extends HeimdallFilter {
 
@@ -22,8 +20,6 @@ public class UniqueID extends HeimdallFilter {
     private static String method;
 
     private static Long referenceId;
-
-    private Helper helper;
 
     public UniqueID() {
 
@@ -42,23 +38,6 @@ public class UniqueID extends HeimdallFilter {
         inboundURL = "{{inboundURL}}";
 
         referenceId = {{referenceId}};
-
-        this.helper = new HelperImpl();
-    }
-
-    @Override
-    public boolean should() {
-
-        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
-        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-    }
-
-    @Override
-    public void execute() throws Throwable {
-        String uid = UUID.randomUUID().toString();
-
-        RequestContext context = RequestContext.getCurrentContext();
-        context.addZuulRequestHeader(IDENTIFIER_ID, uid);
     }
 
     @Override
@@ -75,4 +54,19 @@ public class UniqueID extends HeimdallFilter {
     public int filterOrder() {
         return {{order}};
     }
+
+    @Override
+    public boolean should() {
+
+        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
+        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+    }
+
+    @Override
+    public void execute() throws Throwable {
+
+        IdentifierInterceptorService identifierInterceptorService = (IdentifierInterceptorService) BeanManager.getBean(IdentifierInterceptorService.class);
+        identifierInterceptorService.execute();
+    }
+
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/mock.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/mock.mustache
@@ -1,106 +1,75 @@
-import java.util.*;
+import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
+import br.com.conductor.heimdall.core.util.BeanManager;
+import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.MockInterceptorService;
 
-import org.springframework.util.ReflectionUtils;
-
-import com.google.common.collect.Sets;
 import com.netflix.zuul.context.RequestContext;
 
-import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
-import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
-import br.com.conductor.heimdall.gateway.filter.helper.*;
-import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
-import br.com.conductor.heimdall.core.util.ConstantsInterceptors;
-import br.com.conductor.heimdall.core.util.BeanManager;
-import br.com.conductor.heimdall.middleware.spec.*;
+import java.util.HashSet;
+import java.util.Set;
 
 public class MockInterceptor extends HeimdallFilter {
 
-     private static Set<String> pathsAllowed;
+    private static Set<String> pathsAllowed;
 
-     private static Set<String> pathsNotAllowed;
+    private static Set<String> pathsNotAllowed;
 
-     private static String inboundURL;
+    private static String inboundURL;
 
-     private static String method;
+    private static String method;
 
-     private static Long referenceId;
+    private static Long referenceId;
 
-     private Helper helper;
+    public MockInterceptor() {
 
-     public MockInterceptor() {
+        method = "{{method}}";
 
-          method = "{{method}}";
+        pathsAllowed = new HashSet<>();
+        {{#pathsAllowed}}
+        pathsAllowed.add("{{.}}");
+        {{/pathsAllowed}}
 
-          pathsAllowed = Sets.newHashSet();
-     {{#pathsAllowed}}
-          pathsAllowed.add("{{.}}");
-     {{/pathsAllowed}}      
+        pathsNotAllowed = new HashSet<>();
+        {{#pathsNotAllowed}}
+        pathsNotAllowed.add("{{.}}");
+        {{/pathsNotAllowed}}
 
-          pathsNotAllowed = Sets.newHashSet();
-     {{#pathsNotAllowed}}
-          pathsNotAllowed.add("{{.}}");
-     {{/pathsNotAllowed}}           
-
-          inboundURL = "{{inboundURL}}";
-
-          this.helper = new HelperImpl();
+        inboundURL = "{{inboundURL}}";
 
         referenceId = {{referenceId}};
 
-     }
+    }
 
-     @Override
-     public int filterOrder() {
+    @Override
+    public int filterOrder() {
 
-          return {{order}};
-     }
+        return {{order}};
+    }
 
-     @Override
-     public String filterType() {
+    @Override
+    public String filterType() {
 
-          return "{{executionPoint}}";
-     }
+        return "{{executionPoint}}";
+    }
 
-     @Override
-     public boolean should() {
+    @Override
+    public String getName() {
+        return "{{name}}"
+    }
 
-        LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
-        return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-     }
-     
-     @Override
-     public String getName() {
-     	return "{{name}}"
-     }
+    @Override
+    public boolean should() {
 
-     @Override
-     public void execute() throws Throwable {
-          
-          RequestContext ctx = RequestContext.getCurrentContext();
+       LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
+       return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
+    }
 
-          String status = "{{status}}";     
+    @Override
+    public void execute() throws Throwable {
 
-          boolean jsonValid = helper.json().isJson("{{{body}}}");          
-
-          String body = "";
-          if (jsonValid) {
-               body = helper.json().parse("{{{body}}}");
-
-               helper.call().response().header().add("Content-Type", "application/json");
-          } else {
-
-               body = "{{{body}}}";
-
-               helper.call().response().header().add("Content-Type", "text/plain");
-          }
-          
-          helper.call().response().setBody(body);
-               
-          ctx.setSendZuulResponse(false);
-          ctx.setResponseStatusCode(Integer.valueOf(status));
-
-          TraceContextHolder.getInstance().getActualTrace().trace(ConstantsInterceptors.GLOBAL_MOCK_INTERCEPTOR_LOCALIZED, body);
-     }
+        MockInterceptorService mockInterceptorService = (MockInterceptorService) BeanManager.getBean(MockInterceptorService.class);
+        mockInterceptorService.execute({{status}}, "{{{body}}}");
+    }
 
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/oauth.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/oauth.mustache
@@ -1,116 +1,98 @@
-import java.util.*;
-import com.netflix.zuul.ZuulFilter;
-import com.google.common.collect.Sets;
-import com.netflix.zuul.context.RequestContext;
-import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.enums.TypeOAuth;
-import br.com.conductor.heimdall.core.exception.HeimdallException;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
-import br.com.conductor.heimdall.gateway.filter.helper.*;
+import br.com.conductor.heimdall.gateway.filter.helper.Helper;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.filter.helper.HelperImpl;
-import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.gateway.service.OAuthInterceptorService;
-import br.com.conductor.heimdall.middleware.spec.*;
 import br.com.conductor.heimdall.middleware.spec.Helper;
-import br.com.conductor.heimdall.middleware.spec.Http;
 
+import com.netflix.zuul.context.RequestContext;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class OAuthInterceptor extends HeimdallFilter {
 
-     private static Set<String> pathsAllowed;
+    private static Set<String> pathsAllowed;
 
-     private static Set<String> pathsNotAllowed;
+    private static Set<String> pathsNotAllowed;
 
-     private static String inboundURL;
+    private static String inboundURL;
 
-     private static String method;
+    private static String method;
 
-     private static Long referenceId;
+    private static Long referenceId;
 
-     private Helper helper;
+    private Helper helper;
 
-     private Long providerId = {{providerId}};
+    private Long providerId;
 
-     private int timeAccessToken = {{timeAccessToken}};
+    private int timeAccessToken;
 
-     private int timeRefreshToken = {{timeRefreshToken}};
+    private int timeRefreshToken;
 
-     private String privateKey = "{{privateKey}}";
+    private String privateKey;
 
-     private OAuthInterceptorService oAuthInterceptorService;
+    public OAuthInterceptor() {
 
-     public OAuthInterceptor() {
+        pathsAllowed = new HashSet<>();
+        {{#pathsAllowed}}
+        pathsAllowed.add("{{.}}");
+        {{/pathsAllowed}}
 
-          pathsAllowed = Sets.newHashSet();
-     {{#pathsAllowed}}
-          pathsAllowed.add("{{.}}");
-     {{/pathsAllowed}}
+        pathsNotAllowed = new HashSet<>();
+        {{#pathsNotAllowed}}
+        pathsNotAllowed.add("{{.}}");
+        {{/pathsNotAllowed}}
 
-          pathsNotAllowed = Sets.newHashSet();
-     {{#pathsNotAllowed}}
-          pathsNotAllowed.add("{{.}}");
-     {{/pathsNotAllowed}}
+        inboundURL = "{{inboundURL}}";
 
-          inboundURL = "{{inboundURL}}";
-          method = "{{method}}";
+        method = "{{method}}";
 
-          this.helper = new HelperImpl();
+        referenceId = {{referenceId}};
 
-          referenceId = {{referenceId}};
+        providerId = {{providerId}};
 
-     }
+        timeAccessToken = {{timeAccessToken}};
 
-     @Override
-     public int filterOrder() {
+        timeRefreshToken = {{timeRefreshToken}};
 
-          return {{order}};
-     }
+        privateKey = "{{privateKey}}";
 
-     @Override
-     public String filterType() {
+        this.helper = new HelperImpl();
+    }
 
-          return "{{executionPoint}}";
-     }
+    @Override
+    public int filterOrder() {
 
-     @Override
-     public boolean should() {
+        return {{order}};
+    }
+
+    @Override
+    public String filterType() {
+
+        return "{{executionPoint}}";
+    }
+
+    @Override
+    public String getName() {
+        return "{{name}}"
+    }
+
+    @Override
+    public boolean should() {
 
         LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
         return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-     }
+    }
 
-     @Override
-     public String getName() {
-     	return "{{name}}"
-     }
+    @Override
+    public void execute() throws Throwable {
 
-     @Override
-     public void execute() throws Throwable {
+        OAuthInterceptorService oAuthInterceptorService = (OAuthInterceptorService) BeanManager.getBean(OAuthInterceptorService.class);
+        oAuthInterceptorService.execute(TypeOAuth.{{typeOAuth}}, privateKey, timeAccessToken, timeRefreshToken, providerId, helper);
+    }
 
-        oAuthInterceptorService = (OAuthInterceptorService) BeanManager.getBean(OAuthInterceptorService.class);
-
-        try {
-            oAuthInterceptorService.executeInterceptor(TypeOAuth.{{typeOAuth}}, privateKey, timeAccessToken, timeRefreshToken, providerId, helper);
-        } catch( HeimdallException ex ){
-            generateResponse( ex.getMsgEnum().getMessage(), ex.getMsgEnum().getHttpCode());
-        }
-        return null;
-     }
-
-     /**
-     * Method that sends a Response
-     *
-     * @param message    Response message
-     * @param httpStatus {@link HttpStatus} of the response
-     */
-     private void generateResponse(String message, int httpStatus) {
-         message = "{ \"error\" : \"" + message + "\" }";
-         TraceContextHolder.getInstance().getActualTrace().trace(message);
-         this.helper.call().response().setStatus(httpStatus);
-         this.helper.call().response().header().add("Content-Type", "application/json");
-         this.helper.call().response().setBody(message);
-     }
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/ratting.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/ratting.mustache
@@ -1,140 +1,74 @@
-import java.util.*;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
-
-import org.springframework.cloud.netflix.zuul.filters.support.FilterConstants;
-import org.springframework.http.HttpStatus;
-import org.springframework.util.AntPathMatcher;
-import org.springframework.util.PathMatcher;
-
-import com.google.common.collect.Sets;
-import com.netflix.zuul.context.RequestContext;
-
-import br.com.conductor.heimdall.core.entity.Interceptor;
-import br.com.conductor.heimdall.core.entity.RateLimit;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.core.enums.Interval;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
 import br.com.conductor.heimdall.core.util.BeanManager;
 import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
-import br.com.conductor.heimdall.gateway.filter.helper.*;
-import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
-import br.com.conductor.heimdall.core.repository.RateLimitRepository;
-import br.com.conductor.heimdall.core.util.BeanManager;
-import br.com.conductor.heimdall.middleware.spec.*;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+import br.com.conductor.heimdall.gateway.service.RattingInterceptorService;
+
+import com.netflix.zuul.context.RequestContext;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RateLimitInterceptor extends HeimdallFilter {
 
-     private static Set<String> pathsAllowed;
+    private static Set<String> pathsAllowed;
 
-     private static Set<String> pathsNotAllowed;
+    private static Set<String> pathsNotAllowed;
 
-     private RateLimitRepository repository;
+    private static String inboundURL;
 
-     private static String inboundURL;
+    private static String method;
 
-     private static String method;
+    private static Long referenceId;
 
-     private static Long referenceId;
+    public RateLimitInterceptor() {
 
-     private PathMatcher pathMatcher = new AntPathMatcher();
+        method = "{{method}}";
 
-     private RedissonClient redisson;
+        pathsAllowed = new HashSet<>();
+        {{#pathsAllowed}}
+        pathsAllowed.add("{{.}}");
+        {{/pathsAllowed}}
 
-     private Helper helper;
+        pathsNotAllowed = new HashSet<>();
+        {{#pathsNotAllowed}}
+        pathsNotAllowed.add("{{.}}");
+        {{/pathsNotAllowed}}
 
-     public RateLimitInterceptor() {
+        inboundURL = "{{inboundURL}}";
 
-          method = "{{method}}";
+        referenceId = {{referenceId}};
 
-          pathsAllowed = Sets.newHashSet();
-          {{#pathsAllowed}}
-               pathsAllowed.add("{{.}}");
-          {{/pathsAllowed}}      
+    }
 
-          pathsNotAllowed = Sets.newHashSet();
-          {{#pathsNotAllowed}}
-               pathsNotAllowed.add("{{.}}");
-          {{/pathsNotAllowed}}           
+    @Override
+    public String filterType() {
 
-          inboundURL = "{{inboundURL}}";
+        return "{{executionPoint}}";
+    }
 
-          this.helper = new HelperImpl();
+    @Override
+    public int filterOrder() {
 
-          referenceId = {{referenceId}};
+        return {{order}};
+    }
 
-        }
+    @Override
+    public String getName() {
+        return "{{name}}"
+    }
 
-     @Override
-     public boolean should() {
+    @Override
+    public boolean should() {
 
         LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
         return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-     }
-     
-     @Override
-     public String getName() {
-     	return "{{name}}"
-     }
+    }
 
-     @Override
-     public void execute() throws Throwable {
-          repository = (RateLimitRepository) BeanManager.getBean(RateLimitRepository.class);
-          redisson = (RedissonClient) BeanManager.getBean(RedissonClient.class);
-          RequestContext ctx = RequestContext.getCurrentContext();
-          
-          RLock lock = redisson.getLock("{{name}}");
-          lock.lock();
-
-          RateLimit rate = repository.find("{{path}}");
-          if (rate.getLastRequest() == null) {
-               rate.setLastRequest(LocalDateTime.now());
-          }
-          
-          
-          if (isIntervalEnded(rate)) {
-               rate.reset();
-               rate.decreaseRemaining();
-               repository.save(rate);
-          } else {
-               if (rate.hasRemaining()) {
-                    rate.decreaseRemaining();
-                    repository.save(rate);
-               } else {
-                    ctx.setSendZuulResponse(false);
-                    ctx.setResponseStatusCode(HttpStatus.TOO_MANY_REQUESTS.value());
-                    ctx.setResponseBody(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase());
-               }
-               
-          }
-          lock.unlock();
-     }
-
-     private boolean isIntervalEnded(RateLimit rate) {         
-
-          if (rate.getInterval() == Interval.SECONDS) {
-               return Duration.between(LocalDateTime.now(), rate.getLastRequest()).getSeconds() != 0;
-          } else if (rate.getInterval() == Interval.MINUTES) {
-               return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toMinutes() != 0;
-          } else {
-               return Duration.between(LocalDateTime.now(), rate.getLastRequest()).toHours() != 0;
-          }
-     }
-
-     @Override
-     public String filterType() {
-
-          return "{{executionPoint}}";
-     }
-
-     @Override
-     public int filterOrder() {
-
-          return {{order}};
-     }
+    @Override
+    public void execute() throws Throwable {
+        RattingInterceptorService rattingInterceptorService = (RattingInterceptorService) BeanManager.getBean(RattingInterceptorService.class);
+        rattingInterceptorService.execute("{{name}}", "{{path}}");
+    }
 
 }

--- a/heimdall-gateway/src/main/resources/template-interceptor/whitelist_ip.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/whitelist_ip.mustache
@@ -1,94 +1,81 @@
-import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
-
-import java.util.*;
-
-import com.netflix.zuul.ZuulFilter;
-import com.google.common.collect.Sets;
-import com.netflix.zuul.context.RequestContext;
 import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
-import br.com.conductor.heimdall.gateway.service.LifeCycleService;
-import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
-import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
-import br.com.conductor.heimdall.middleware.spec.*;
 import br.com.conductor.heimdall.core.util.BeanManager;
+import br.com.conductor.heimdall.gateway.filter.HeimdallFilter;
 import br.com.conductor.heimdall.gateway.service.IpsInterceptorService;
-import org.springframework.http.HttpStatus;
+import br.com.conductor.heimdall.gateway.service.LifeCycleService;
+
+import com.netflix.zuul.context.RequestContext;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class WhitelistInterceptor extends HeimdallFilter {
 
-     private static Set<String> pathsAllowed;
+    private static Set<String> pathsAllowed;
 
-     private static Set<String> pathsNotAllowed;
+    private static Set<String> pathsNotAllowed;
 
-     private static Set<String> whitelist;
+    private static Set<String> whitelist;
 
-     private static String inboundURL;
+    private static String inboundURL;
 
-     private static String method;
+    private static String method;
 
-     private static Long referenceId;
+    private static Long referenceId;
 
-     private IpsInterceptorService ipsInterceptorService;
+    public WhitelistInterceptor() {
 
-     public WhitelistInterceptor() {
+        pathsAllowed = new HashSet<>();
+        {{#pathsAllowed}}
+        pathsAllowed.add("{{.}}");
+        {{/pathsAllowed}}
 
-          pathsAllowed = Sets.newHashSet(); {{#pathsAllowed}}
-          pathsAllowed.add("{{.}}");     {{/pathsAllowed}}
+        pathsNotAllowed = new HashSet<>();
+        {{#pathsNotAllowed}}
+        pathsNotAllowed.add("{{.}}");
+        {{/pathsNotAllowed}}
 
-          pathsNotAllowed = Sets.newHashSet();     {{#pathsNotAllowed}}
-          pathsNotAllowed.add("{{.}}");     {{/pathsNotAllowed}}
+        whitelist = new HashSet<>();
+        {{#ips}}
+        whitelist.add("{{.}}");
+        {{/ips}}
 
-          whitelist = Sets.newHashSet();   {{#ips}}
-          whitelist.add("{{.}}");      {{/ips}}
+        inboundURL = "{{inboundURL}}";
 
-          inboundURL = "{{inboundURL}}";
-          method = "{{method}}";
+        method = "{{method}}";
 
-          referenceId = {{referenceId}};
+        referenceId = {{referenceId}};
 
-     }
+    }
 
-     @Override
-     public int filterOrder() {
+    @Override
+    public int filterOrder() {
 
-          return {{order}};
-     }
+        return {{order}};
+    }
 
-     @Override
-     public String filterType() {
+    @Override
+    public String filterType() {
 
-          return "{{executionPoint}}";
-     }
+        return "{{executionPoint}}";
+    }
 
-     @Override
-     public boolean should() {
+    @Override
+    public String getName() {
+        return "{{name}}";
+    }
+
+    @Override
+    public boolean should() {
 
         LifeCycleService lifeCycleService = (LifeCycleService) BeanManager.getBean(LifeCycleService.class);
         return lifeCycleService.should(InterceptorLifeCycle.{{lifeCycle}}, pathsAllowed, pathsNotAllowed, inboundURL, method, RequestContext.getCurrentContext().getRequest(), referenceId);
-     }
+    }
 
-     @Override
-     public String getName() {
-     	return "{{name}}";
-     }
+    @Override
+    public void execute() throws Throwable {
 
-     @Override
-     public void execute() throws Throwable {
-
-            try {
-
-                RequestContext ctx = RequestContext.getCurrentContext();
-
-                ipsInterceptorService = (IpsInterceptorService) BeanManager.getBean(IpsInterceptorService.class);
-
-                if (!ipsInterceptorService.verifyIpInList(ctx.getRequest(), whitelist)){
-                    ctx.getResponse().sendError(HttpStatus.UNAUTHORIZED.value(), "IP unauthorized");
-                }
-            } catch (IOException e) {
-                TraceContextHolder.getInstance().getActualTrace().trace(e.getMessage());
-            } finally {
-                return null;
-            }
-
-     }
+        IpsInterceptorService ipsInterceptorService = (IpsInterceptorService) BeanManager.getBean(IpsInterceptorService.class);
+        ipsInterceptorService.executeWhiteList(whitelist);
+    }
 }


### PR DESCRIPTION
Refactored the Interceptor templates to use service classes.

The mustache templates are used to generate the Groovy file for the interceptors. Even though this works correctly it limits the ability to test and makes updates more difficult.

This pull request refactors the mustache templates by removing unused imports, dead code and transfers all the business logic from the templates to appropriate service classes.