### PR TITLE
Mongo date optimization

### DIFF
--- a/heimdall-config/src/main/resources/shared/application.yml
+++ b/heimdall-config/src/main/resources/shared/application.yml
@@ -52,6 +52,7 @@ heimdall:
 #        password: admin
 #        queueSize: 500
 #        discardingThreshold: 0
+#        zoneId: America/Sao_Paulo
     trace:
         printAllTrace: true
         sanitizes:

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/environment/Property.java
@@ -153,6 +153,7 @@ public class Property {
           private String password;
           private Long queueSize;
           private Long discardingThreshold;
+          private String zoneId;
           
      }
 

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/MongoLogConnector.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/util/MongoLogConnector.java
@@ -327,7 +327,7 @@ public class MongoLogConnector implements Serializable {
          List<LogTrace> list;
          Long totalElements = query.count();
 
-         query = query.order("-trace.insertedOnDate");
+         query = query.order("-ts");
 
          page = page == null ? PAGE : page;
          limit = limit == null || limit > LIMIT ? LIMIT : limit;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
@@ -29,11 +29,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.BsonDateTime;
 import org.bson.Document;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,6 +51,9 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 	private MongoClient mongoClient;
 	private MongoCollection<Document> collection;
 
+    @Setter
+    @Getter
+	private String zoneId;
 	@Setter
 	@Getter
 	private String url;
@@ -67,17 +70,19 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 	@Getter
 	private String uri;
 
-	public MongoDBAppender(String url, Long port, String dataBase, String collectionName) {
+	public MongoDBAppender(String url, Long port, String dataBase, String collectionName, String zoneId) {
 		this.url = url;
 		this.port = port;
 		this.dataBase = dataBase;
 		this.collectionName = collectionName;
+		this.zoneId = zoneId;
 	}
 
-	public MongoDBAppender(String uri, String dataBase, String collectionName) {
+	public MongoDBAppender(String uri, String dataBase, String collectionName, String zoneId) {
 		this.uri = uri;
 		this.dataBase = dataBase;
 		this.collectionName = collectionName;
+        this.zoneId = zoneId;
 	}
 
 	@Override
@@ -107,8 +112,13 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
 	@Override
 	protected void append(ILoggingEvent e) {
+        ZoneId zoneId = ZoneId.of(this.zoneId);
+
+        // Offset in milliseconds based on the informed Zone
+        long offset = zoneId.getRules().getOffset(Instant.now()).getTotalSeconds() * 1000;
+
 		Map<String, Object> objLog = new HashMap<>();
-		objLog.put("ts", new Date(LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli()));
+		objLog.put("ts", new BsonDateTime(e.getTimeStamp() + offset));
 		objLog.put("trace", BasicDBObject.parse(e.getFormattedMessage()));
 		objLog.put("level", e.getLevel().toString());
 		objLog.put("logger", e.getLoggerName());

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/appender/MongoDBAppender.java
@@ -31,6 +31,8 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,7 +108,7 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 	@Override
 	protected void append(ILoggingEvent e) {
 		Map<String, Object> objLog = new HashMap<>();
-		objLog.put("ts", new Date(e.getTimeStamp()));
+		objLog.put("ts", new Date(LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli()));
 		objLog.put("trace", BasicDBObject.parse(e.getFormattedMessage()));
 		objLog.put("level", e.getLevel().toString());
 		objLog.put("logger", e.getLoggerName());

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
@@ -64,9 +64,9 @@ public class LogConfiguration {
              // Creating custom MongoDBAppender
              Appender<ILoggingEvent> appender;
              if (property.getMongo().getUrl() != null) {
-          	   appender = new MongoDBAppender(property.getMongo().getUrl(), property.getMongo().getDataBase(), property.getMongo().getCollection());
+          	   appender = new MongoDBAppender(property.getMongo().getUrl(), property.getMongo().getDataBase(), property.getMongo().getCollection(), property.getMongo().getZoneId());
              } else {
-          	   appender = new MongoDBAppender(property.getMongo().getServerName(), property.getMongo().getPort(), property.getMongo().getDataBase(), property.getMongo().getCollection());            	   
+          	   appender = new MongoDBAppender(property.getMongo().getServerName(), property.getMongo().getPort(), property.getMongo().getDataBase(), property.getMongo().getCollection(), property.getMongo().getZoneId());
              }
              appender.setContext(lc);
              appender.start();
@@ -74,12 +74,12 @@ public class LogConfiguration {
              // Creating AsyncAppender
              int queueSize = (property.getMongo().getQueueSize() != null) ? property.getMongo().getQueueSize().intValue() : DEFAULT_QUEUE_SIZE;
 
-             Appender<ILoggingEvent> asyncAppender = new AsyncAppender();
-             ((AsyncAppender) asyncAppender).setQueueSize(queueSize);
+             AsyncAppender asyncAppender = new AsyncAppender();
+             asyncAppender.setQueueSize(queueSize);
              if (property.getMongo().getDiscardingThreshold() != null) {            	 
-            	 ((AsyncAppender) asyncAppender).setDiscardingThreshold(property.getMongo().getDiscardingThreshold().intValue());
+            	 asyncAppender.setDiscardingThreshold(property.getMongo().getDiscardingThreshold().intValue());
              }
-             ((AsyncAppender) asyncAppender).addAppender(appender);
+             asyncAppender.addAppender(appender);
              asyncAppender.start();
 
              logger.addAppender(asyncAppender);


### PR DESCRIPTION
Changed the way that Heimdall saves the timestamp to mongodb so it can be formatted for timezones.