### PR TITLE
Removed duplicated method from AMQPRouteService

### DIFF
--- a/heimdall-api/src/main/java/br/com/conductor/heimdall/api/resource/OperationResource.java
+++ b/heimdall-api/src/main/java/br/com/conductor/heimdall/api/resource/OperationResource.java
@@ -206,7 +206,7 @@ public class OperationResource {
      @PreAuthorize(ConstantsPrivilege.PRIVILEGE_REFRESH_OPERATION)
      public ResponseEntity<?> refresh(@PathVariable("apiId") Long apiId, @PathVariable("resourceId") Long resourceId) {
 
-          aMQPRouteService.dispatchAllRoutes();
+          aMQPRouteService.dispatchRoutes();
 
           return ResponseEntity.noContent().build();
      }

--- a/heimdall-api/src/main/java/br/com/conductor/heimdall/api/resource/ResourceResource.java
+++ b/heimdall-api/src/main/java/br/com/conductor/heimdall/api/resource/ResourceResource.java
@@ -181,7 +181,7 @@ public class ResourceResource {
     @PreAuthorize(ConstantsPrivilege.PRIVILEGE_REFRESH_RESOURCE)
     public ResponseEntity<?> refresh(@PathVariable("apiId") Long apiId) {
 
-        aMQPRouteService.dispatchAllRoutes();
+        aMQPRouteService.dispatchRoutes();
 
         return ResponseEntity.noContent().build();
     }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/amqp/AMQPRouteService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/amqp/AMQPRouteService.java
@@ -41,22 +41,10 @@ public class AMQPRouteService {
 
      /**
       * Dispatch a message to refresh zuul routes
-      * 
-      * @param apiId
-      * @param resourceId
       */
      public void dispatchRoutes() {
 
           rabbitTemplate.convertAndSend(RabbitConstants.EXCHANGE_FANOUT_HEIMDALL_ROUTES, "", "");
      }
 
-     /**
-      * Dispatch a message to refresh all zuul routes
-      * 
-      */
-     public void dispatchAllRoutes() {
-
-          rabbitTemplate.convertAndSend(RabbitConstants.EXCHANGE_FANOUT_HEIMDALL_ROUTES, "", "");
-
-     }
 }


### PR DESCRIPTION
The `br/com/conductor/heimdall/core/service/amqp/AMQPRouteService` class had duplicated methods

Removed one and factored out all uses of it.