### PR TITLE
OAuth privatekey/client_id constraint

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/InterceptorService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/InterceptorService.java
@@ -24,11 +24,9 @@ package br.com.conductor.heimdall.core.service;
 import br.com.conductor.heimdall.core.converter.GenericConverter;
 import br.com.conductor.heimdall.core.converter.InterceptorMap;
 import br.com.conductor.heimdall.core.dto.*;
-import br.com.conductor.heimdall.core.dto.interceptor.OAuthDTO;
 import br.com.conductor.heimdall.core.dto.interceptor.RateLimitDTO;
 import br.com.conductor.heimdall.core.dto.page.InterceptorPage;
 import br.com.conductor.heimdall.core.entity.*;
-import br.com.conductor.heimdall.core.enums.InterceptorLifeCycle;
 import br.com.conductor.heimdall.core.enums.Status;
 import br.com.conductor.heimdall.core.enums.TypeInterceptor;
 import br.com.conductor.heimdall.core.exception.ExceptionMessage;
@@ -53,17 +51,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static br.com.conductor.heimdall.core.exception.ExceptionMessage.*;
 import static br.com.conductor.heimdall.core.util.Constants.MIDDLEWARE_API_ROOT;
 import static br.com.twsoftware.alfred.object.Objeto.isBlank;
 
 /**
- * This class provides methos to create, read, update and delete a {@link Interceptor} resource.<br/>
+ * This class provides methods to create, read, update and delete a {@link Interceptor} resource.<br/>
  * This class also performs a validation  before it saves or deletes a {@link Interceptor}.
  *
  * @author Filipe Germano
@@ -93,9 +88,6 @@ public class InterceptorService {
 
     @Autowired
     private RateLimitRepository ratelimitRepository;
-
-    @Autowired
-    private AppRepository appRepository;
 
     @Autowired
     private AMQPInterceptorService amqpInterceptorService;
@@ -179,10 +171,6 @@ public class InterceptorService {
             mountRatelimitInRedis(interceptor);
         }
 
-        if (TypeInterceptor.OAUTH == interceptor.getType()) {
-            checkAppAndClientId(interceptor);
-        }
-
         interceptor = interceptorRepository.save(interceptor);
 
         if (TypeInterceptor.MIDDLEWARE.equals(interceptor.getType())) {
@@ -238,10 +226,6 @@ public class InterceptorService {
 
         if (TypeInterceptor.RATTING == interceptor.getType()) {
             mountRatelimitInRedis(interceptor);
-        }
-
-        if (TypeInterceptor.OAUTH == interceptor.getType()) {
-            checkAppAndClientId(interceptor);
         }
 
         interceptor = interceptorRepository.save(interceptor);
@@ -422,31 +406,4 @@ public class InterceptorService {
         return path;
     }
 
-    /*
-     * When adding a OAuth Interceptor a privateKey is expected.
-     * This privateKey must be the ClientId from an App that is related to the Api via a Plan,
-     * if not throws an Exception.
-     */
-    private void checkAppAndClientId(Interceptor interceptor) {
-        try {
-            String content = interceptor.getContent();
-            OAuthDTO oAuthDTO = JsonUtils.convertJsonToObject(content, OAuthDTO.class);
-
-            final String privateKey = oAuthDTO.getPrivateKey();
-            App app = appRepository.findByClientId(privateKey);
-
-            HeimdallException.checkThrow(app == null, APP_NOT_EXIST);
-
-            final List<Plan> appPlans = app.getPlans();
-            final List<Plan> apiPlans = interceptor.getApi().getPlans();
-
-            Set<Plan> common = new HashSet<>(appPlans);
-            common.retainAll(apiPlans);
-
-            HeimdallException.checkThrow(common.size() == 0, INTERCEPTOR_NO_APP_FOUND);
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-            ExceptionMessage.INTERCEPTOR_INVALID_CONTENT.raise(TypeInterceptor.OAUTH.name(), TemplateUtils.TEMPLATE_OAUTH);
-        }
-    }
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OAuthService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/OAuthService.java
@@ -23,10 +23,12 @@ package br.com.conductor.heimdall.core.service;
 import static br.com.conductor.heimdall.core.util.ConstantsOAuth.*;
 import br.com.conductor.heimdall.core.dto.request.OAuthRequest;
 import br.com.conductor.heimdall.core.dto.response.TokenImplicit;
+import br.com.conductor.heimdall.core.entity.App;
 import br.com.conductor.heimdall.core.entity.OAuthAuthorize;
 import br.com.conductor.heimdall.core.entity.Provider;
 import br.com.conductor.heimdall.core.entity.TokenOAuth;
 import br.com.conductor.heimdall.core.exception.*;
+import br.com.conductor.heimdall.core.repository.AppRepository;
 import br.com.conductor.heimdall.core.repository.OAuthAuthorizeRepository;
 import br.com.conductor.heimdall.core.util.JwtUtils;
 import br.com.twsoftware.alfred.object.Objeto;
@@ -50,8 +52,12 @@ public class OAuthService {
 
     @Autowired
     private OAuthAuthorizeRepository oAuthAuthorizeRepository;
+
     @Autowired
     private ProviderService providerService;
+
+    @Autowired
+    private AppRepository appRepository;
 
     /**
      * Generates {@link TokenOAuth} from Code Authorize or RefreshToken
@@ -245,6 +251,11 @@ public class OAuthService {
      * @param token    The token
      */
     public void saveToken(String clientId, String token, LocalDateTime expirationDate, String grantType, int expirationTime) {
+
+        App app = appRepository.findByClientId(clientId);
+
+        HeimdallException.checkThrow(app == null, ExceptionMessage.CLIENT_ID_NOT_FOUND);
+
         OAuthAuthorize oAuthAuthorizeAccessToken = new OAuthAuthorize();
         oAuthAuthorizeAccessToken.setClientId(clientId);
         oAuthAuthorizeAccessToken.setTokenAuthorize(token);

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/JsonImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/JsonImpl.java
@@ -20,6 +20,7 @@ package br.com.conductor.heimdall.gateway.filter.helper;
  * ==========================LICENSE_END===================================
  */
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
+import com.fasterxml.jackson.core.JsonParser;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -207,25 +209,16 @@ public class JsonImpl implements Json {
 
 	public boolean isJson(String string) {
 
-		boolean valid = false;
 		try {
+			JsonParser parser = new ObjectMapper().getFactory().createParser(string);
 
-			JSONObject jsonObject = new JSONObject(string);
-			if (Objeto.notBlank(jsonObject)) {
+			while (parser.nextToken() != null) {}
 
-				valid = true;
-			}
-		} catch (JSONException e) {
+			return true;
+		} catch (IOException e) {
+		    return false;
+        }
 
-			try {
-				new JSONArray(string);
-				valid = true;
-			} catch (JSONException ex1) {
-				valid = false;
-			}
-		}
-
-		return valid;
 	}
 
 	private ObjectMapper mapper() {


### PR DESCRIPTION
PR #124  added a constraint between the OAuth privatekey and an App's client_id. This constraint should not exist, this PR fixes that among other fixes to better handle error in the requests.

Also fixed Json validation by JsonImpl class. There was an error that cause the validation to return true when an trailing comma was left at the end of an json.

Eg.:
Valid json
```json
{
  "key": "value"
}
```

Invalid json that was being tagged as valid
```json
{
  "key": "value",
}
```

Now it is correctly marked as invalid.
