### PR TITLE
*Fix the breakline in the pom to solve the problem with docker plugin.

### DIFF
--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -202,8 +202,7 @@
 				<configuration>
 					<baseImage>${docker.baseImage}</baseImage>
 					<imageName>${docker.imageName}</imageName>
-					<entryPoint>["java", "-Xmx4g", "-Xms1g", "-jar",
-						"/${project.build.finalName}.jar"]</entryPoint>
+					<entryPoint>["java", "-Xmx4g", "-Xms1g", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 					<forceTags>true</forceTags>
 					<serverId>${docker.serverId}</serverId>
 					<registryUrl>${docker.registryUrl}</registryUrl>


### PR DESCRIPTION
Actually with the breakline in the pom, we can't upload the dockerfile to docker hub.