### PR TITLE
[BUGFIX] Client Id was being saved incorrectly to trace

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallDecorationFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallDecorationFilter.java
@@ -174,7 +174,7 @@ public class HeimdallDecorationFilter extends PreDecorationFilter {
         }
 
         if (ctx.getRequest().getHeader(CLIENT_ID) != null) {
-            TraceContextHolder.getInstance().getActualTrace().setClientId(ctx.getRequest().getHeader(ACCESS_TOKEN));
+            TraceContextHolder.getInstance().getActualTrace().setClientId(ctx.getRequest().getHeader(CLIENT_ID));
         }
         if (heimdallRoute != null) {
 


### PR DESCRIPTION
AccessToken was being wrongly saved as client_id to trace