### PR TITLE
[BUGFIX] Scopes filter fix

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/ScopesFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/ScopesFilter.java
@@ -119,6 +119,9 @@ public class ScopesFilter extends ZuulFilter {
 
             if (Objects.isNull(operation)) return;
 
+            // If the allowedOperations is empty it means that Scopes are not set
+            if (allowedOperations.isEmpty()) return;
+
             if (!allowedOperations.contains(operation)) {
                 context.setSendZuulResponse(false);
                 context.setResponseStatusCode(HttpStatus.FORBIDDEN.value());


### PR DESCRIPTION
When scopes are not set the verification would fail if a valid client_id was used