### PR TITLE
Hotfix OAuth

### DIFF
--- a/heimdall-core/src/main/resources/liquibase/changelog/20181203115559-update-table-provider-with-provider-default.xml
+++ b/heimdall-core/src/main/resources/liquibase/changelog/20181203115559-update-table-provider-with-provider-default.xml
@@ -33,20 +33,20 @@
 			<column name="DESCRIPTION" value="DEFAULT PROVIDER OF THE HEIMDALL" />
 			<column name="PATH" value=""/>
 			<column name="CREATION_DATE"  valueDate="${now}" />
-			<column name="PROVIDER_DEFAULT" valueBoolean="true" />
+			<column name="PROVIDER_DEFAULT" valueBoolean="${true}" />
 		</insert>
 	</changeSet>
 
 	<changeSet id="03" author="conductor\dijalma.silva">
 		<preConditions>
 			<sqlCheck expectedResult="1">
-				SELECT count(*) FROM PROVIDERS P WHERE P.PROVIDER_DEFAULT = 'true' OR P.PROVIDER_DEFAULT = 1
+				SELECT count(*) FROM PROVIDERS P WHERE P.PROVIDER_DEFAULT = ${true}
 			</sqlCheck>
 		</preConditions>
 
 		<sql>
-			insert into provider_params (name, location, value, creation_date, provider_id) values ('access_token' , 'HEADER', '', CURRENT_TIMESTAMP, (select id from providers p where P.PROVIDER_DEFAULT = 'true' OR P.PROVIDER_DEFAULT = 1));
-			insert into provider_params (name, location, value, creation_date, provider_id) values ('client_id' , 'HEADER', '', CURRENT_TIMESTAMP, (select id from providers p where P.PROVIDER_DEFAULT = 'true' OR P.PROVIDER_DEFAULT = 1));
+			insert into provider_params (name, location, value, creation_date, provider_id) values ('access_token' , 'HEADER', '', CURRENT_TIMESTAMP, (select id from providers p where P.PROVIDER_DEFAULT = ${true}));
+			insert into provider_params (name, location, value, creation_date, provider_id) values ('client_id' , 'HEADER', '', CURRENT_TIMESTAMP, (select id from providers p where P.PROVIDER_DEFAULT = ${true}));
 		</sql>
 	</changeSet>
 

--- a/heimdall-core/src/main/resources/liquibase/changelog/20190128114155-recreate-table-oauth-authorizes.xml
+++ b/heimdall-core/src/main/resources/liquibase/changelog/20190128114155-recreate-table-oauth-authorizes.xml
@@ -1,0 +1,46 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <changeSet id="01" author="conductor\dijalma.silva">
+        <dropTable tableName="OAUTH_AUTHORIZES"/>
+    </changeSet>
+
+    <changeSet id="02" author="conductor\dijalma.silva">
+        <createTable tableName="OAUTH_AUTHORIZES">
+            <column name="ID" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="PK_OAUTH_AUTHORIZES" nullable="false"/>
+            </column>
+            <column name="CLIENT_ID" type="VARCHAR(250)">
+                <constraints nullable="false" />
+            </column>
+            <column name="TOKEN_AUTHORIZE" type="VARCHAR(250)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="GRANT_TYPE" type="varchar(100)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="EXPIRATION_DATE" type="datetime">
+                <constraints nullable="true"/>
+            </column>
+            <column name="EXPIRATION_TIME" type="bigint">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="03" author="conductor\dijalma.silva">
+        <addUniqueConstraint tableName="OAUTH_AUTHORIZES" columnNames="ID" constraintName="UQ_OAUTH_AUTHORIZES"/>
+        <addForeignKeyConstraint
+                baseTableName="OAUTH_AUTHORIZES" baseColumnNames="CLIENT_ID"
+                constraintName="FK_CLIENT_ID" deferrable="false"
+                initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+                referencedTableName="APPS" referencedColumnNames="CLIENT_ID"
+                validate="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/heimdall-core/src/main/resources/liquibase/changelog/20190128114155-recreate-table-oauth-authorizes.xml
+++ b/heimdall-core/src/main/resources/liquibase/changelog/20190128114155-recreate-table-oauth-authorizes.xml
@@ -12,7 +12,7 @@
 
     <changeSet id="02" author="conductor\dijalma.silva">
         <createTable tableName="OAUTH_AUTHORIZES">
-            <column name="ID" type="BIGINT">
+            <column name="ID" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="PK_OAUTH_AUTHORIZES" nullable="false"/>
             </column>
             <column name="CLIENT_ID" type="VARCHAR(250)">

--- a/heimdall-core/src/main/resources/liquibase/master.xml
+++ b/heimdall-core/src/main/resources/liquibase/master.xml
@@ -31,5 +31,6 @@
     <include file="changelog/20181129141113-remove-null-constraints-from-value-in-provider-param.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20181203115559-update-table-provider-with-provider-default.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20181112113200-added-scopes-structure.xml" relativeToChangelogFile="true"/>
+    <include file="changelog/20190128114155-recreate-table-oauth-authorizes.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/heimdall-core/src/main/resources/liquibase/master.xml
+++ b/heimdall-core/src/main/resources/liquibase/master.xml
@@ -16,8 +16,12 @@
     <property name="floatType" value="float" dbms="mysql, oracle"/>
     <property name="booleanType" value="varchar(6)" dbms="h2"/>
     <property name="booleanType" value="varchar(1)" dbms="mssql"/>
-    
-    
+
+    <property name="true" value="1" dbms="mssql, oracle" />
+    <property name="false" value="0" dbms="mssql, oracle" />
+    <property name="true" value="true" dbms="postgresql, h2, mysql" />
+    <property name="false" value="false" dbms="postgresql, h2, mysql" />
+
     <property name="inteiro" value="bigint" dbms="mssql, h2, oracle"/>
     
     <include file="changelog/20180501121201-initial-core-schemes.xml" relativeToChangelogFile="true"/>

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -355,7 +355,7 @@ public class OAuthInterceptorService {
      */
 
     private void passwordFlow(Provider provider, OAuthRequest oAuthRequest, String clientId, String privateKey, int timeAccessToken, int timeRefreshToken, String claimsJson, String accessToken) {
-
+        validateClientId(clientId);
         validateInProvider(provider, clientId, accessToken);
 
         TokenOAuth tokenOAuth = oAuthService.generateTokenOAuth(oAuthRequest, oAuthRequest.getClientId(), privateKey, timeAccessToken, timeRefreshToken, claimsJson);
@@ -369,7 +369,7 @@ public class OAuthInterceptorService {
      * OAuth2.0 Implicit Flow
      */
     private void implicitFlow(Provider provider, OAuthRequest oAuthRequest, String clientId, String privateKey, int timeAccessToken, String claimsJson, String accessToken) {
-
+        validateClientId(clientId);
         validateInProvider(provider, clientId, accessToken);
 
         TokenImplicit tokenImplicit = oAuthService.generateTokenImplicit(oAuthRequest, privateKey, timeAccessToken, claimsJson);

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -392,17 +392,16 @@ public class OAuthInterceptorService {
     }
 
     private void validateClientId(String clientId) {
-        App appActive = appRepository.findAppActive(clientId);
+        final App appActive = appRepository.findAppActive(clientId);
         HeimdallException.checkThrow(Objects.isNull(appActive), ExceptionMessage.CLIENT_ID_NOT_FOUND);
     }
 
 
     private void validateInProvider(Provider provider, String clientId, String accessToken) {
         if (provider.isProviderDefault()) {
-            App appActive = appRepository.findAppActive(clientId);
-            HeimdallException.checkThrow(Objects.isNull(appActive), ExceptionMessage.CLIENT_ID_NOT_FOUND);
+            final App appActive = appRepository.findAppActive(clientId);
 
-            List<AccessToken> accessTokens = appActive.getAccessTokens();
+            final List<AccessToken> accessTokens = appActive.getAccessTokens();
             HeimdallException.checkThrow(accessTokens.stream().noneMatch(ac -> ac.getCode().equals(accessToken)), ExceptionMessage.PROVIDER_USER_UNAUTHORIZED);
         } else {
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -161,14 +161,12 @@ public class OAuthInterceptorService {
 
         HeimdallException.checkThrow(Objeto.isBlank(oAuthRequest.getClientId()), ExceptionMessage.CLIENT_ID_NOT_FOUND);
 
-        Provider provider = oAuthService.getProvider(providerId);
-
         switch (oAuthRequest.getGrantType().toUpperCase()) {
             case GRANT_TYPE_PASSWORD:
-                passwordFlow(provider, oAuthRequest, clientId, privateKey, timeAccessToken, timeRefreshToken, claimsJson, accessToken);
+                passwordFlow(oAuthService.getProvider(providerId), oAuthRequest, clientId, privateKey, timeAccessToken, timeRefreshToken, claimsJson, accessToken);
                 break;
             case GRANT_TYPE_IMPLICIT:
-                implicitFlow(oAuthRequest, privateKey, timeAccessToken, claimsJson);
+                implicitFlow(oAuthService.getProvider(providerId), oAuthRequest, clientId, privateKey, timeAccessToken, claimsJson, accessToken);
                 break;
             case GRANT_TYPE_REFRESH_TOKEN:
                 refreshFlow(oAuthRequest, privateKey, timeAccessToken, timeRefreshToken, claimsJson);
@@ -356,27 +354,7 @@ public class OAuthInterceptorService {
 
     private void passwordFlow(Provider provider, OAuthRequest oAuthRequest, String clientId, String privateKey, int timeAccessToken, int timeRefreshToken, String claimsJson, String accessToken) {
 
-        if (provider.isProviderDefault()) {
-            App appActive = appRepository.findAppActive(clientId);
-            HeimdallException.checkThrow(Objects.isNull(appActive), ExceptionMessage.CLIENT_ID_NOT_FOUND);
-
-            List<AccessToken> accessTokens = appActive.getAccessTokens();
-            HeimdallException.checkThrow(accessTokens.stream().noneMatch(ac -> ac.getCode().equals(accessToken)), ExceptionMessage.ACCESS_DENIED);
-        } else {
-            Http http = helper.http().url(provider.getPath());
-
-            http = addAllParamsToRequestProvider(http, provider.getProviderParams());
-
-            try {
-                ApiResponse apiResponse = http.sendPost();
-
-                HeimdallException.checkThrow(!(Series.valueOf(apiResponse.getStatus()) == Series.SUCCESSFUL), ExceptionMessage.PROVIDER_USER_UNAUTHORIZED);
-
-            } catch (Exception ex) {
-                log.error(ex.getMessage(), ex);
-                throw new UnauthorizedException(ExceptionMessage.PROVIDER_USER_UNAUTHORIZED);
-            }
-        }
+        validateInProvider(provider, clientId, accessToken);
 
         TokenOAuth tokenOAuth = oAuthService.generateTokenOAuth(oAuthRequest, oAuthRequest.getClientId(), privateKey, timeAccessToken, timeRefreshToken, claimsJson);
         if (Objects.nonNull(tokenOAuth)) {
@@ -388,7 +366,10 @@ public class OAuthInterceptorService {
     /*
      * OAuth2.0 Implicit Flow
      */
-    private void implicitFlow(OAuthRequest oAuthRequest, String privateKey, int timeAccessToken, String claimsJson) {
+    private void implicitFlow(Provider provider, OAuthRequest oAuthRequest, String clientId, String privateKey, int timeAccessToken, String claimsJson, String accessToken) {
+
+        validateInProvider(provider, clientId, accessToken);
+
         TokenImplicit tokenImplicit = oAuthService.generateTokenImplicit(oAuthRequest, privateKey, timeAccessToken, claimsJson);
         if (Objects.nonNull(tokenImplicit)) {
             tokenImplicit.setToken_type("bearer");
@@ -406,5 +387,29 @@ public class OAuthInterceptorService {
             generateResponseWithSuccess(helper.json().parse(tokenOAuth));
         }
 
+    }
+
+    private void validateInProvider(Provider provider, String clientId, String accessToken) {
+        if (provider.isProviderDefault()) {
+            App appActive = appRepository.findAppActive(clientId);
+            HeimdallException.checkThrow(Objects.isNull(appActive), ExceptionMessage.CLIENT_ID_NOT_FOUND);
+
+            List<AccessToken> accessTokens = appActive.getAccessTokens();
+            HeimdallException.checkThrow(accessTokens.stream().noneMatch(ac -> ac.getCode().equals(accessToken)), ExceptionMessage.PROVIDER_USER_UNAUTHORIZED);
+        } else {
+
+            Http http = helper.http().url(provider.getPath());
+            http = addAllParamsToRequestProvider(http, provider.getProviderParams());
+
+            try {
+
+                final ApiResponse apiResponse = http.sendPost();
+                HeimdallException.checkThrow(!(Series.valueOf(apiResponse.getStatus()) == Series.SUCCESSFUL), ExceptionMessage.PROVIDER_USER_UNAUTHORIZED);
+
+            } catch (Exception ex) {
+                log.error(ex.getMessage(), ex);
+                throw new UnauthorizedException(ExceptionMessage.PROVIDER_USER_UNAUTHORIZED);
+            }
+        }
     }
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -36,10 +36,12 @@ import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Helper;
 import br.com.conductor.heimdall.middleware.spec.Http;
 import br.com.twsoftware.alfred.object.Objeto;
+import com.netflix.zuul.context.RequestContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -388,6 +390,12 @@ public class OAuthInterceptorService {
         }
 
     }
+
+    private void validateClientId(String clientId) {
+        App appActive = appRepository.findAppActive(clientId);
+        HeimdallException.checkThrow(Objects.isNull(appActive), ExceptionMessage.CLIENT_ID_NOT_FOUND);
+    }
+
 
     private void validateInProvider(Provider provider, String clientId, String accessToken) {
         if (provider.isProviderDefault()) {

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/OAuthInterceptorService.java
@@ -36,12 +36,10 @@ import br.com.conductor.heimdall.middleware.spec.ApiResponse;
 import br.com.conductor.heimdall.middleware.spec.Helper;
 import br.com.conductor.heimdall.middleware.spec.Http;
 import br.com.twsoftware.alfred.object.Objeto;
-import com.netflix.zuul.context.RequestContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
**Describe Hoffix**
* The original liquibase script that created the OAUTH_AUTHORIZE did not specified the contraints names, that caused the deletion of the client_id contraint to not work properly with multiple diferent databases
* The Implicit flow did not authorized with the provider for the first request
* The client id validation was not occuring for password and implicit flows
 
**What was done**
* Created a new liquibase script that recreates the OAUTH_AUTHORIZE table and adds the constraints names
* Factored out the provider validation to a method that is used by all OAuth flows methods
* Created client_id validation method to be used by all OAuth flows methods