### PR TITLE
AccessToken interceptor should be allowed at Plan lifecycle

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/InterceptorService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/InterceptorService.java
@@ -168,10 +168,7 @@ public class InterceptorService {
         List<Long> ignoredOperations = ignoredValidate(interceptorDTO.getIgnoredOperations(), operationRepository);
         HeimdallException.checkThrow(Objeto.notBlank(ignoredOperations), INTERCEPTOR_IGNORED_INVALID, ignoredOperations.toString());
 
-        if (TypeInterceptor.CLIENT_ID.equals(interceptor.getType()) ||
-                TypeInterceptor.ACCESS_TOKEN.equals(interceptor.getType())) {
-            HeimdallException.checkThrow(InterceptorLifeCycle.PLAN.equals(interceptor.getLifeCycle()), INTERCEPTOR_INVALID_LIFECYCLE, interceptor.getType().name());
-        }
+        HeimdallException.checkThrow((TypeInterceptor.CLIENT_ID.equals(interceptor.getType()) && InterceptorLifeCycle.PLAN.equals(interceptor.getLifeCycle())), INTERCEPTOR_INVALID_LIFECYCLE, interceptor.getType().name());
 
         if (TypeInterceptor.RATTING == interceptor.getType()) {
             mountRatelimitInRedis(interceptor);


### PR DESCRIPTION
The AccessToken interceptor should be allowed at the Plan LifeCycle.

This bug was introduced by PR #197 