### PR TITLE
Bug in Resource and Interceptors

### DIFF
--- a/heimdall-frontend/src/components/interceptors/DnDInterceptor.js
+++ b/heimdall-frontend/src/components/interceptors/DnDInterceptor.js
@@ -138,6 +138,7 @@ class DnDInterceptor extends Component {
     }
 
     handleRemoveInterceptor = () => {
+        this.hide();
         this.props.handleDelete(this.props.interceptor);
     }
 

--- a/heimdall-frontend/src/containers/Resources.js
+++ b/heimdall-frontend/src/containers/Resources.js
@@ -12,7 +12,7 @@ import {PrivilegeUtils} from "../utils/PrivilegeUtils"
 import {privileges} from '../constants/privileges-types'
 import ResourceForm from '../components/resources/ResourceForm'
 import ComponentAuthority from "../components/policy/ComponentAuthority"
-import {clearResources, getAllResourcesByApi, remove, toggleModal} from '../actions/resources'
+import {clearResources, getAllResourcesByApi, remove, resetResource, toggleModal} from '../actions/resources'
 
 const HeimdallPanel = HeimdallCollapse.Panel;
 const ButtonGroup = Button.Group;
@@ -73,9 +73,10 @@ class Resources extends Component {
     }
 
     handleSave(e) {
-
         this.addResource.onSubmitResource()
         this.props.clearResources()
+        this.props.resetResource()
+        this.setState({...this.state, resourceSelected: 0});
     }
 
     handleCancel(e) {
@@ -186,6 +187,7 @@ const mapDispatchToProps = dispatch => {
     return {
         getResourcesByApi: bindActionCreators(getAllResourcesByApi, dispatch),
         clearResources: bindActionCreators(clearResources, dispatch),
+        resetResource: bindActionCreators(resetResource, dispatch),
         toggleModal: bindActionCreators(toggleModal, dispatch),
         remove: bindActionCreators(remove, dispatch)
     }


### PR DESCRIPTION
**Describe the bug**
It is not possible to add a new Resource after editing an existing one.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to one Api
2. Click on Resources
3. Edit a existing Resource
4. Try to create a new Resource
5. See error

**Expected behavior**
The user should always be able to create a new resource.

---

**Describe the bug**
The popover that shows when clicking in a intercetor does not disapear after deleting a interceptor.

**To Reproduce**
Steps to reproduce the behavior:
1. Navigate to the interceptors editing page
2. Add at least two interceptors
3. Click on the leftmost interceptor and delete it
4. See error

**Expected behavior**
The popover should disapear after the deletion of a interceptor.