### PR TITLE
[HOTFIX] - Middleware template

### DIFF
--- a/heimdall-gateway/src/main/resources/template-interceptor/middleware.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/middleware.mustache
@@ -83,11 +83,10 @@ public class MiddlewareInterceptor extends HeimdallFilter {
 
         try {
             def middleware = m.instance("{{{content}}}");
+            ctx.setSendZuulResponse(false);
             middleware.run(helper);
         } catch (Exception e) {
             throw e;
-        } finally {
-            ctx.setSendZuulResponse(false);
         }
     }
 

--- a/heimdall-gateway/src/main/resources/template-interceptor/middleware.mustache
+++ b/heimdall-gateway/src/main/resources/template-interceptor/middleware.mustache
@@ -86,6 +86,10 @@ public class MiddlewareInterceptor extends HeimdallFilter {
             ctx.setSendZuulResponse(false);
             middleware.run(helper);
         } catch (Exception e) {
+            helper.call().response().header().add("Content-Type", "application/json");
+            helper.call().response().setBody("{\"message\":\"Middleware Exception\"}");
+            helper.call().response().setStatus(500);
+            ctx.setSendZuulResponse(false);
             throw e;
         }
     }


### PR DESCRIPTION
The middleware template should let the request continue if it is set by a middleware.
The template now has a default response if a middleware throws an exception