### PR TITLE
Json parse backslash

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<name>heimdall-api</name>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/JsonImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/JsonImpl.java
@@ -31,6 +31,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -65,7 +66,7 @@ public class JsonImpl implements Json {
 		try {
 			String json = mapper().writeValueAsString(body);
 
-			return json;
+			return StringEscapeUtils.unescapeJava(json);
 		} catch (JsonProcessingException e) {
 
 			log.error(e.getMessage(), e);
@@ -79,7 +80,7 @@ public class JsonImpl implements Json {
 
 			JSONObject jsonObject = new JSONObject(string);
 
-			return jsonObject.toString();
+			return StringEscapeUtils.unescapeJava(jsonObject.toString());
 		} catch (JSONException e) {
 			try {
 				JSONArray array = new JSONArray(string);
@@ -100,7 +101,7 @@ public class JsonImpl implements Json {
 
 			String jsonInString = mapper().writeValueAsString(object);
 
-			return jsonInString;
+			return StringEscapeUtils.unescapeJava(jsonInString);
 		} catch (Exception e) {
 
 			log.error(e.getMessage(), e);

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,16 @@
 		    	<role>Developer</role>
 		    </roles>
 	  	</developer>
+		<developer>
+			<id>manoel.filho</id>
+			<name>Manoel Dijalma</name>
+			<email>manoel.filho at conductor.com.br</email>
+			<organization>Conductor Tecnologia SA</organization>
+			<organizationUrl>http://www.conductor.com.br</organizationUrl>
+			<roles>
+				<role>Developer</role>
+			</roles>
+		</developer>
 	  	<developer>
 		   	<id>marcelo.rodrigues</id>
 		    <name>Marcelo Rodrigues</name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -253,12 +253,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>2.0.1-SNAPSHOT</version>
+				<version>2.0.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>2.0.1-SNAPSHOT</version>
+				<version>2.0.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>


### PR DESCRIPTION
**Describe Bug**

If a json object has a string that contains backslashes, the Mapper would add a second backslash as an escape character for the java string.

**Describe Hotfix**
This PR adds the use of StringEscapeUtils.unescapeJava() method to prevent that behaviour.