### PR TITLE
Fix liquibase startup

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<name>heimdall-api</name>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-core/src/main/resources/liquibase/changelog/20190222142000-recreate-default-plan-column.xml
+++ b/heimdall-core/src/main/resources/liquibase/changelog/20190222142000-recreate-default-plan-column.xml
@@ -5,14 +5,22 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
+	<changeSet id="01" author="conductor\marcos.filho">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="PLANS" />
+            <columnExists tableName="PLANS" columnName="DEFAULT_PLAN"/>
+            <dbms type="mssql"/>
+        </preConditions>
 
-    <changeSet id="01" author="conductor\marcelo.rodrigues">
+        <dropUniqueConstraint tableName="PLANS" constraintName="DF_PLANS_DEFAULT_PLAN" />
+    </changeSet>
+	
+    <changeSet id="02" author="conductor\marcelo.rodrigues">
         <preConditions>
             <tableExists tableName="PLANS" />
             <columnExists tableName="PLANS" columnName="DEFAULT_PLAN"/>
         </preConditions>
 
-        <dropUniqueConstraint tableName="PLANS" constraintName="DF_PLANS_DEFAULT_PLAN" />
         <dropColumn tableName="PLANS" columnName="DEFAULT_PLAN"/>
 
         <rollback>
@@ -24,7 +32,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="02" author="conductor\marcelo.rodrigues">
+    <changeSet id="03" author="conductor\marcelo.rodrigues">
         <preConditions>
             <tableExists tableName="PLANS" />
             <not>
@@ -34,13 +42,8 @@
 
         <addColumn tableName="PLANS">
             <column name="DEFAULT_PLAN" defaultValue="false" type="boolean">
-                <constraints nullable="false"/>
+                <constraints nullable="false" />
             </column>
         </addColumn>
-
-        <rollback>
-            <dropUniqueConstraint tableName="PLANS" constraintName="DF_PLANS_DEFAULT_PLAN" />
-            <dropColumn tableName="PLANS" columnName="DEFAULT_PLAN"/>
-        </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/heimdall-core/src/main/resources/liquibase/master.xml
+++ b/heimdall-core/src/main/resources/liquibase/master.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     
     <property name="now" value="now()" dbms="mysql,h2"/>
-    <property name="now" value="current_timestamp" dbms="postgresql"/>
+    <property name="now" value="now()" dbms="postgresql"/>
     <property name="now" value="GETDATE()" dbms="mssql" />
     <property name="now" value="sysdate" dbms="oracle"/>
 

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -253,12 +253,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>2.0.1-SNAPSHOT</version>
+				<version>2.0.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>2.0.1-SNAPSHOT</version>
+				<version>2.0.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>


### PR DESCRIPTION
Currently the startup project on empty PostgreSQL fail because the liquibase crash on conditions specifically to SQLServer, with this PR I fix this case and now we can startup the project with PostgreSQL or SQLServer without problem.