### PR TITLE
Reset FilterDetail from HeimdallFilter

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
@@ -19,6 +19,7 @@
  */
 package br.com.conductor.heimdall.gateway.filter;
 
+import br.com.conductor.heimdall.gateway.trace.StackTraceImpl;
 import org.springframework.stereotype.Component;
 
 import com.netflix.zuul.ZuulFilter;
@@ -85,6 +86,7 @@ public abstract class HeimdallFilter extends ZuulFilter {
                detail.setStatus(Constants.SUCCESS);
           } catch (Throwable e) {
                detail.setStatus(Constants.FAILED);
+               detail.setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), null));
           } finally {
                long endTime = System.currentTimeMillis();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
@@ -1,6 +1,3 @@
-
-package br.com.conductor.heimdall.gateway.filter;
-
 /*-
  * =========================LICENSE_START==================================
  * heimdall-gateway
@@ -10,9 +7,9 @@ package br.com.conductor.heimdall.gateway.filter;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +17,8 @@ package br.com.conductor.heimdall.gateway.filter;
  * limitations under the License.
  * ==========================LICENSE_END===================================
  */
+package br.com.conductor.heimdall.gateway.filter;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.stereotype.Component;
 
 import com.netflix.zuul.ZuulFilter;
@@ -29,7 +26,6 @@ import com.netflix.zuul.context.RequestContext;
 
 import br.com.conductor.heimdall.core.util.Constants;
 import br.com.conductor.heimdall.gateway.trace.FilterDetail;
-import br.com.conductor.heimdall.gateway.trace.StackTraceImpl;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
 
 /**
@@ -48,6 +44,7 @@ public abstract class HeimdallFilter extends ZuulFilter {
      
      @Override
      public boolean shouldFilter() {
+          this.detail.clear();
           long startTime = System.currentTimeMillis();
           boolean should = true;
           
@@ -88,7 +85,6 @@ public abstract class HeimdallFilter extends ZuulFilter {
                detail.setStatus(Constants.SUCCESS);
           } catch (Throwable e) {
                detail.setStatus(Constants.FAILED);
-               detail.setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), ExceptionUtils.getStackTrace(e)));
           } finally {
                long endTime = System.currentTimeMillis();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
@@ -86,7 +86,7 @@ public abstract class HeimdallFilter extends ZuulFilter {
                detail.setStatus(Constants.SUCCESS);
           } catch (Throwable e) {
                detail.setStatus(Constants.FAILED);
-               detail.setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), null));
+               detail.setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage()));
           } finally {
                long endTime = System.currentTimeMillis();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogRequestFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogRequestFilter.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -81,7 +80,7 @@ public class LogRequestFilter extends ZuulFilter {
             detail.setStatus(Constants.SUCCESS);
         } catch (Throwable e) {
             detail.setStatus(Constants.FAILED);
-            TraceContextHolder.getInstance().getActualTrace().setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), ExceptionUtils.getStackTrace(e)));
+            TraceContextHolder.getInstance().getActualTrace().setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage()));
         } finally {
             long endTime = System.currentTimeMillis();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -89,7 +88,7 @@ public class LogResponseFilter extends ZuulFilter {
             detail.setStatus(Constants.SUCCESS);
         } catch (Throwable e) {
             detail.setStatus(Constants.FAILED);
-            TraceContextHolder.getInstance().getActualTrace().setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), ExceptionUtils.getStackTrace(e)));
+            TraceContextHolder.getInstance().getActualTrace().setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage()));
         } finally {
             long endTime = System.currentTimeMillis();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/ScopesFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/ScopesFilter.java
@@ -27,7 +27,6 @@ import br.com.conductor.heimdall.gateway.trace.StackTraceImpl;
 import br.com.conductor.heimdall.gateway.trace.TraceContextHolder;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -76,7 +75,7 @@ public class ScopesFilter extends ZuulFilter {
             detail.setStatus(Constants.SUCCESS);
         } catch (Throwable e) {
             detail.setStatus(Constants.FAILED);
-            TraceContextHolder.getInstance().getActualTrace().setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage(), ExceptionUtils.getStackTrace(e)));
+            TraceContextHolder.getInstance().getActualTrace().setStackTrace(new StackTraceImpl(e.getClass().getName(), e.getMessage()));
         } finally {
             long endTime = System.currentTimeMillis();
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/FilterDetail.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/FilterDetail.java
@@ -19,6 +19,8 @@
  */
 package br.com.conductor.heimdall.gateway.trace;
 
+import br.com.conductor.heimdall.middleware.spec.StackTrace;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
@@ -45,6 +47,9 @@ public class FilterDetail {
      @Getter(AccessLevel.NONE)
      private long totalTimeInMillis;
 
+     @JsonInclude(JsonInclude.Include.NON_NULL)
+     private StackTrace stackTrace;
+
      /**
       * Returns the total time in milliseconds.
       * 
@@ -61,5 +66,6 @@ public class FilterDetail {
           this.timeInMillisShould = 0;
           this.status = null;
           this.totalTimeInMillis = 0;
+          this.stackTrace = null;
      }
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/FilterDetail.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/FilterDetail.java
@@ -1,6 +1,3 @@
-
-package br.com.conductor.heimdall.gateway.trace;
-
 /*-
  * =========================LICENSE_START==================================
  * heimdall-gateway
@@ -10,9 +7,9 @@ package br.com.conductor.heimdall.gateway.trace;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,9 +17,8 @@ package br.com.conductor.heimdall.gateway.trace;
  * limitations under the License.
  * ==========================LICENSE_END===================================
  */
+package br.com.conductor.heimdall.gateway.trace;
 
-import br.com.conductor.heimdall.middleware.spec.StackTrace;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
@@ -49,9 +45,6 @@ public class FilterDetail {
      @Getter(AccessLevel.NONE)
      private long totalTimeInMillis;
 
-     @JsonInclude(JsonInclude.Include.NON_NULL)
-     private StackTrace stackTrace;
-
      /**
       * Returns the total time in milliseconds.
       * 
@@ -60,5 +53,13 @@ public class FilterDetail {
      public long getTotalTimeInMillis() {
 
           return timeInMillisRun + timeInMillisShould;
+     }
+
+     public void clear() {
+          this.name = null;
+          this.timeInMillisRun = 0;
+          this.timeInMillisShould = 0;
+          this.status = null;
+          this.totalTimeInMillis = 0;
      }
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/StackTraceImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/StackTraceImpl.java
@@ -22,6 +22,7 @@ package br.com.conductor.heimdall.gateway.trace;
  */
 
 import br.com.conductor.heimdall.middleware.spec.StackTrace;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -42,6 +43,7 @@ public class StackTraceImpl implements StackTrace {
 
      public String message;
 
+     @JsonInclude(JsonInclude.Include.NON_NULL)
      public String stack;
 
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/StackTraceImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/StackTraceImpl.java
@@ -25,7 +25,6 @@ import br.com.conductor.heimdall.middleware.spec.StackTrace;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * Data class that represents a custom Stack Trace.
@@ -36,7 +35,6 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class StackTraceImpl implements StackTrace {
 
      public String clazz;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/StackTraceImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/StackTraceImpl.java
@@ -46,4 +46,7 @@ public class StackTraceImpl implements StackTrace {
      @JsonInclude(JsonInclude.Include.NON_NULL)
      public String stack;
 
+     public StackTraceImpl(String clazz, String message) {
+          this(clazz, message, null);
+     }
 }


### PR DESCRIPTION
**Describe the bug**

During the logging process the stacktrace from a filter of another request would still be logged on another successful request. That happens because the FilterDetail object inside HeimdallFilter was not being reset for each request.
This PR solves this issue.