### PR TITLE
Fixing queryParams issues

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<name>heimdall-api</name>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
@@ -67,6 +67,8 @@ public class HttpImpl implements Http {
     private RestTemplate restTemplate;
 
     private boolean enableHandler;
+    
+    private MultiValueMap<String, String> queryParams;
 
     public HttpImpl() {
         this.enableHandler = false;
@@ -108,10 +110,10 @@ public class HttpImpl implements Http {
 
     @Override
     public HttpImpl queryParam(String name, String value) {
+        queryParams = Objects.isNull(queryParams) ? new LinkedMultiValueMap<>() : queryParams;
 
         if (Objects.nonNull(value)) {
-
-            uriComponentsBuilder.queryParam(name, value);
+            queryParams.add(name, value);
         }
 
         return this;
@@ -149,7 +151,8 @@ public class HttpImpl implements Http {
 
         setUIDFromInterceptor();
         ResponseEntity<String> entity;
-
+    
+        updateQueryParams();
         if (headers.isEmpty()) {
 
             entity = rest().getForEntity(uriComponentsBuilder.build().encode().toUri(), String.class);
@@ -171,6 +174,8 @@ public class HttpImpl implements Http {
 
         setUIDFromInterceptor();
         ResponseEntity<String> entity;
+    
+        updateQueryParams();
         if (headers.isEmpty()) {
 
             requestBody = new HttpEntity<>(body);
@@ -204,6 +209,8 @@ public class HttpImpl implements Http {
 
         setUIDFromInterceptor();
         ResponseEntity<String> entity;
+    
+        updateQueryParams();
         if (headers.isEmpty()) {
 
             requestBody = new HttpEntity<>(body);
@@ -233,7 +240,8 @@ public class HttpImpl implements Http {
 
         setUIDFromInterceptor();
         ResponseEntity<String> entity;
-
+    
+        updateQueryParams();
         if (headers.isEmpty()) {
             entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.DELETE, null,
                     String.class);
@@ -254,7 +262,8 @@ public class HttpImpl implements Http {
     public ApiResponseImpl sendPatch() {
 
         ResponseEntity<String> entity;
-
+    
+        updateQueryParams();
         if (headers.isEmpty()) {
             requestBody = new HttpEntity<>(body);
             entity = rest().exchange(uriComponentsBuilder.build().encode().toUri(), HttpMethod.PATCH, requestBody,
@@ -307,5 +316,10 @@ public class HttpImpl implements Http {
             headers.add(IDENTIFIER_ID, context.getZuulRequestHeaders().get(IDENTIFIER_ID));
         }
     }
-
+    
+    private void updateQueryParams() {
+        if (uriComponentsBuilder != null && queryParams != null && !queryParams.isEmpty()) {
+            uriComponentsBuilder.queryParams(queryParams);
+        }
+    }
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImpl.java
@@ -71,11 +71,13 @@ public class HttpImpl implements Http {
     private MultiValueMap<String, String> queryParams;
 
     public HttpImpl() {
-        this.enableHandler = false;
+        this(false);
+    
     }
 
     public HttpImpl(boolean enableHandler) {
         this.enableHandler = enableHandler;
+        queryParams = new LinkedMultiValueMap<>();
     }
 
     @Override
@@ -110,7 +112,6 @@ public class HttpImpl implements Http {
 
     @Override
     public HttpImpl queryParam(String name, String value) {
-        queryParams = Objects.isNull(queryParams) ? new LinkedMultiValueMap<>() : queryParams;
 
         if (Objects.nonNull(value)) {
             queryParams.add(name, value);

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImplTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImplTest.java
@@ -35,6 +35,33 @@ public class HttpImplTest {
      }
      
      @Test
+     public void sendGetWithNoParams() {
+          Mockito.when(restTemplate.getForEntity(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(responseEntity);
+          
+          ApiResponse apiResponse = subject.url("https://www.google.com/search")
+                                           .sendGet();
+          assertNotNull(apiResponse);
+          assertNotNull(apiResponse.getStatus());
+          assertNotNull(apiResponse.getBody());
+          assertEquals(apiResponse.getStatus().intValue(), HttpStatus.OK.value());
+          assertEquals(apiResponse.getBody(), "OK");
+     }
+     
+     @Test
+     public void sendGetWithInvalidParams() {
+          Mockito.when(restTemplate.getForEntity(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(responseEntity);
+          
+          ApiResponse apiResponse = subject.url("https://www.google.com/search")
+                                           .queryParam("search", null)
+                                           .sendGet();
+          assertNotNull(apiResponse);
+          assertNotNull(apiResponse.getStatus());
+          assertNotNull(apiResponse.getBody());
+          assertEquals(apiResponse.getStatus().intValue(), HttpStatus.OK.value());
+          assertEquals(apiResponse.getBody(), "OK");
+     }
+     
+     @Test
      public void setUrlThenAddQueryParam() {
           Mockito.when(restTemplate.getForEntity(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(responseEntity);
           

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImplTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/helper/HttpImplTest.java
@@ -1,0 +1,64 @@
+package br.com.conductor.heimdall.gateway.filter.helper;
+
+import br.com.conductor.heimdall.middleware.spec.ApiResponse;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpImplTest {
+     
+     @InjectMocks
+     private HttpImpl subject;
+     
+     @Mock
+     private RestTemplate restTemplate;
+     
+     private ResponseEntity<String> responseEntity;
+     
+     @Before
+     public void setup() {
+          responseEntity = ResponseEntity.ok("OK");
+     }
+     
+     @Test
+     public void setUrlThenAddQueryParam() {
+          Mockito.when(restTemplate.getForEntity(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(responseEntity);
+          
+          ApiResponse apiResponse = subject.url("https://www.google.com/search")
+                                           .queryParam("search", "Heimdall")
+                                           .sendGet();
+          assertNotNull(apiResponse);
+          assertNotNull(apiResponse.getStatus());
+          assertNotNull(apiResponse.getBody());
+          assertEquals(apiResponse.getStatus().intValue(), HttpStatus.OK.value());
+          assertEquals(apiResponse.getBody(), "OK");
+     }
+     
+     @Test
+     public void addQueryParamThenSetUrl() {
+          Mockito.when(restTemplate.getForEntity(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(responseEntity);
+          
+          ApiResponse apiResponse = subject.queryParam("search", "Heimdall")
+                                           .url("https://www.google.com/search")
+                                           .sendGet();
+          assertNotNull(apiResponse);
+          assertNotNull(apiResponse.getStatus());
+          assertNotNull(apiResponse.getBody());
+          assertEquals(apiResponse.getStatus().intValue(), HttpStatus.OK.value());
+          assertEquals(apiResponse.getBody(), "OK");
+     }
+}

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>2.1.1-SNAPSHOT</version>
+	<version>2.1.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -263,12 +263,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>2.1.1-SNAPSHOT</version>
+				<version>2.1.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>2.1.1-SNAPSHOT</version>
+				<version>2.1.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>


### PR DESCRIPTION
Described on #241 
Added a map to keep the query params. When a request method is used, the map will be passed to an existing `uriComponentsBuilder`.