### PR TITLE
Fixing issues when saving apps and adding validation when saving access tokens

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<name>heimdall-api</name>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/AppDTO.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/AppDTO.java
@@ -56,5 +56,7 @@ public class AppDTO implements Serializable {
      
      private Status status;
      
+     @NotNull
+     @Size(min = 1)
      private List<ReferenceIdDTO> plans;
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/persist/AccessTokenPersist.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/persist/AccessTokenPersist.java
@@ -52,6 +52,8 @@ public class AccessTokenPersist implements Serializable {
      
      private LocalDateTime expiredDate;
 
+     @NotNull
+     @Size(min = 1)
      private List<ReferenceIdDTO> plans;
      
      private Status status;

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/persist/AppPersist.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/dto/persist/AppPersist.java
@@ -56,6 +56,8 @@ public class AppPersist implements Serializable {
 
     private Status status;
 
+    @NotNull
+    @Size(min = 1)
     private List<ReferenceIdDTO> plans;
 
     private String clientId;

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/AccessToken.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/AccessToken.java
@@ -103,6 +103,7 @@ public class AccessToken implements Serializable {
                status = Status.ACTIVE;
           }
           creationDate = LocalDateTime.now();
+          code = code.trim();
      }
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/App.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/App.java
@@ -114,6 +114,7 @@ public class App implements Serializable {
         }
 
         creationDate = LocalDateTime.now();
+        clientId = clientId.trim();
     }
 
     @PostLoad

--- a/heimdall-frontend/src/components/access-tokens/AccessTokenForm.js
+++ b/heimdall-frontend/src/components/access-tokens/AccessTokenForm.js
@@ -52,11 +52,22 @@ class AccessTokenForm extends Component {
     checkApp = (rule, value, callback) => {
         if (this.props.appSource.some(app => app.id === value)) {
             const app = this.props.appSource.filter(app => app.id === value)[0];
+            if (app.plans == undefined || app.plans.length == 0) {
+                callback(i18n.t('app_plans_invalid'))
+            }
             this.setState({...this.state, plans: app.plans})
             callback();
             return
         }
         callback(i18n.t('you_need_select_app'));
+    }
+
+    checkToken = (rule, value, callback) => {
+        if (value !== value.trim()) {
+            callback(i18n.t('please_check_token_spacing'))
+        }
+        callback()
+        return
     }
 
     render() {
@@ -79,7 +90,8 @@ class AccessTokenForm extends Component {
                                     getFieldDecorator('code', {
                                         initialValue: accessToken && accessToken.code,
                                         rules: [
-                                            {min: 6, message: i18n.t('min_6_characters_to_token')}
+                                            {min: 6, message: i18n.t('min_6_characters_to_token')},
+                                            {validator: this.checkToken}
                                         ]
                                     })(<Input
                                         disabled={!PrivilegeUtils.verifyPrivileges([privileges.PRIVILEGE_CREATE_ACCESSTOKEN, privileges.PRIVILEGE_UPDATE_ACCESSTOKEN])}/>)
@@ -129,7 +141,10 @@ class AccessTokenForm extends Component {
                             <FormItem label={i18n.t('plans')}>
                                 {
                                     getFieldDecorator('plans', {
-                                        initialValue: accessToken && accessToken.plans.map(plan => plan.id)
+                                        initialValue: accessToken && accessToken.plans.map(plan => plan.id),
+                                        rules: [
+                                            {required: true, message: i18n.t('please_pick_plan')}
+                                        ]
                                     })(<Checkbox.Group className='checkbox-conductor'>
                                         {plans && plans.map((plan, index) => {
                                             return <Checkbox key={index} value={plan.id}

--- a/heimdall-frontend/src/components/apps/AppForm.js
+++ b/heimdall-frontend/src/components/apps/AppForm.js
@@ -51,6 +51,14 @@ class AppForm extends Component {
         callback(i18n.t('you_need_select_developer'));
     }
 
+    checkClientId = (rule, value, callback) => {
+        if (value !== value.trim()) {
+            callback(i18n.t('please_check_client_id_spacing'))
+        }
+        callback()
+        return
+    }
+
     render() {
         const {getFieldDecorator} = this.props.form
 
@@ -108,7 +116,8 @@ class AppForm extends Component {
                                     getFieldDecorator('clientId', {
                                         initialValue: app && app.clientId,
                                         rules: [
-                                            {min: 6, message: i18n.t('min_6_characters_to_client_id')}
+                                            {min: 6, message: i18n.t('min_6_characters_to_client_id')},
+                                            {validator: this.checkClientId}
                                         ]
                                     })(<Input
                                         disabled={!PrivilegeUtils.verifyPrivileges([privileges.PRIVILEGE_CREATE_APP, privileges.PRIVILEGE_UPDATE_APP])}/>)
@@ -157,7 +166,10 @@ class AppForm extends Component {
                                 <FormItem label={i18n.t('plans')}>
                                     {
                                         getFieldDecorator('plans', {
-                                            initialValue: app && app.plans.map(plan => plan.id)
+                                            initialValue: app && app.plans.map(plan => plan.id),
+                                            rules: [
+                                                {required: true, message: i18n.t('please_pick_plan')}
+                                            ]
                                         })(<Checkbox.Group className='checkbox-conductor'>
                                             {this.props.plans && this.props.plans.content.map((plan, index) => {
                                                 return <Checkbox key={index} value={plan.id}

--- a/heimdall-frontend/src/i18n/en.js
+++ b/heimdall-frontend/src/i18n/en.js
@@ -160,6 +160,7 @@ export default {
         'min_5_characters_to_description': 'Min of 5 Characters to description!',
         'min_6_characters_to_client_id': 'Min of 6 Characters to clientId!',
         'please_input_email_developer': 'Please, input a email of developer!',
+        'please_pick_plan': 'Please choose at least one plan',
         'please_input_your_name': 'Please, input your name!',
         'please_input_valid_email': 'Please, input a valid email!',
         'please_input_your_environment_name': 'Please, input your environment name!',
@@ -246,6 +247,9 @@ export default {
         'min_4_characters_to_name': 'Min of 4 Characters to name!',
         'available_privileges': 'Available privileges',
         'attributed_privileges': 'Attributed privileges',
-        'default_plan_this_api': 'Default'
+        'default_plan_this_api': 'Default',
+        'app_plans_invalid': 'App\'s plans are invalid!',
+        'please_check_token_spacing': 'Please check token\'s spacing!',
+        'please_check_client_id_spacing': 'Please check Client ID\'s spacing!'   
     }
 }

--- a/heimdall-frontend/src/i18n/pt-br.js
+++ b/heimdall-frontend/src/i18n/pt-br.js
@@ -160,6 +160,7 @@ export default {
         'min_5_characters_to_description': 'A descrição deve ter no mínimo 5 caracteres!',
         'min_6_characters_to_client_id': 'O ID do Cliente deve ter no mínimo 6 caracteres!',
         'please_input_email_developer': 'Por favor, insira o email de um desenvolvedor!',
+        'please_pick_plan': 'Por favor, selecione ao menos um Plano!',
         'please_input_your_name': 'Por favor, insira seu nome!',
         'please_input_valid_email': 'Por favor, insira um email válido!',
         'please_input_your_environment_name': 'Por favor, insira o nome do ambiente!',
@@ -246,6 +247,9 @@ export default {
         'min_4_characters_to_name': 'O nome deve ter no mínimo 4 caracteres!',
         'available_privileges': 'Papéis disponíveis',
         'attributed_privileges': 'Papéis atribuídos',
-        'default_plan_this_api': 'Plano padrão'
+        'default_plan_this_api': 'Plano padrão',
+        'app_plans_invalid': 'Planos do App são invalidos!',
+        'please_check_token_spacing': 'Por favor, verificar espaçamentos no Token!',
+        'please_check_client_id_spacing': 'Por favor, verificar espaçamentos no Client ID!'
     }
 }

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.1.1-SNAPSHOT</version>
+		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>2.1.1-SNAPSHOT</version>
+	<version>2.1.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -263,12 +263,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>2.1.1-SNAPSHOT</version>
+				<version>2.1.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>2.1.1-SNAPSHOT</version>
+				<version>2.1.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>


### PR DESCRIPTION
**Front end changes**

**App form:**
- Added new validation when saving/updating apps. Now users must always associate a plan to the given app;
- Validating clientId when saving/updating apps. It should check if there's blank spaces before or after it's value, then indicate that that should not happen.

**Access token form:**
- When selecting an app, validate if it has at least one associated plan, if it does not, show an error message;
- Validating if the user selected at least one plan before saving;
- Same validation done on App's client id: must not have blank spaces before or after the access token value.

**Changes on Heimdall Core**
- Added new constraints to AccessTokenPersist, AppPersist and AppDTO, so they will always require at least one plan (or it's ID);
- Trimming App's _clientId_ and Access Token's _code_ before persisting.