### PR TITLE
ClientId and AccessToken headers

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/AccessTokenInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/AccessTokenInterceptorService.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,20 +56,22 @@ public class AccessTokenInterceptorService {
      */
     public void validate(Long apiId, Location location) {
 
-        HttpServletRequest req = RequestContext.getCurrentContext().getRequest();
+        RequestContext context = RequestContext.getCurrentContext();
 
         String clientId;
         String accessToken;
         if (Location.HEADER.equals(location)) {
-            clientId = req.getHeader(CLIENT_ID);
-            accessToken = req.getHeader(ACCESS_TOKEN);
+            clientId = context.getZuulRequestHeaders().get(CLIENT_ID);
+            accessToken = context.getZuulRequestHeaders().get(ACCESS_TOKEN);
+
+            if (clientId == null) clientId = context.getRequest().getHeader(CLIENT_ID);
+            if (accessToken == null) accessToken = context.getRequest().getHeader(ACCESS_TOKEN);
         } else {
-            clientId = req.getParameter(CLIENT_ID);
-            accessToken = req.getParameter(ACCESS_TOKEN);
+            clientId = context.getRequest().getParameter(CLIENT_ID);
+            accessToken = context.getRequest().getParameter(ACCESS_TOKEN);
         }
 
         this.validateAccessToken(apiId, clientId, accessToken);
-
     }
 
     /**
@@ -86,7 +87,12 @@ public class AccessTokenInterceptorService {
 
         TraceContextHolder.getInstance().getActualTrace().setAccessToken(DigestUtils.digestMD5(accessToken));
 
-        if ((accessToken != null && !accessToken.isEmpty()) && (clientId != null && !clientId.isEmpty())) {
+        if (clientId == null || clientId.isEmpty()) {
+            buildResponse(String.format(ConstantsInterceptors.GLOBAL_CLIENT_ID_OR_ACESS_TOKEN_NOT_FOUND, "Client Id"));
+            return;
+        }
+
+        if (accessToken != null && !accessToken.isEmpty()) {
 
             AccessToken token = accessTokenRepository.findAccessTokenActive(accessToken);
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/ClientIdInterceptorService.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/service/ClientIdInterceptorService.java
@@ -31,8 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
-
 import static br.com.conductor.heimdall.core.util.Constants.INTERRUPT;
 import static br.com.conductor.heimdall.gateway.util.ConstantsContext.CLIENT_ID;
 
@@ -53,13 +51,16 @@ public class ClientIdInterceptorService {
      */
     public void validate(Long apiId, Location location) {
 
-        HttpServletRequest req = RequestContext.getCurrentContext().getRequest();
+        RequestContext context = RequestContext.getCurrentContext();
 
         String clientId;
-        if (Location.HEADER.equals(location))
-            clientId = req.getHeader(CLIENT_ID);
+        if (Location.HEADER.equals(location)) {
+            clientId = context.getZuulRequestHeaders().get(CLIENT_ID);
+
+            if (clientId == null) clientId = context.getRequest().getHeader(CLIENT_ID);
+        }
         else
-            clientId = req.getParameter(CLIENT_ID);
+            clientId = context.getRequest().getParameter(CLIENT_ID);
 
         this.validateClientId(apiId, clientId);
     }


### PR DESCRIPTION
Fixed the way that the ClientIdInterceptorService and AccessTokenInterceptorService fetch the access_token and client_id headers.

The priority is for the headers set via a Custom interceptor, this allows the user to override any client_id or access_token sent in the original request. If no such interceptor exists, the headers from the original request is used.