### PR TITLE
Trace filter change

### DIFF
--- a/heimdall-api/src/main/resources/application.yml
+++ b/heimdall-api/src/main/resources/application.yml
@@ -141,7 +141,7 @@ management:
 
 zuul:
     filter:
-        root: /tmp/interceptores
+        root: /tmp/interceptors
         interval: 8
 
 security:

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/Trace.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/Trace.java
@@ -1,6 +1,7 @@
 package br.com.conductor.heimdall.core.entity;
 
 import java.util.List;
+import java.util.Map;
 
 import br.com.conductor.heimdall.core.trace.FilterDetail;
 import br.com.conductor.heimdall.core.trace.GeneralTrace;
@@ -49,7 +50,7 @@ public class Trace {
 
     private List<GeneralTrace> traces;
     
-    private List<FilterDetail> filters;
+    private Map<String, FilterDetail> filters;
 
     private String profile;
 

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/trace/FilterDetail.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/trace/FilterDetail.java
@@ -36,8 +36,6 @@ import lombok.Setter;
 @Data
 public class FilterDetail {
 
-     private String name;
-
      private long timeInMillisRun;
 
      private long timeInMillisShould;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/configuration/LogConfiguration.java
@@ -94,10 +94,10 @@ public class LogConfiguration {
 			Logger logger = (Logger) LoggerFactory.getLogger("logstash");
 			logger.setAdditive(false);
 
-			LogstashTcpSocketAppender appender = new net.logstash.logback.appender.LogstashTcpSocketAppender();
+			LogstashTcpSocketAppender appender = new LogstashTcpSocketAppender();
 			appender.addDestination(property.getLogstash().getDestination());
 
-			LogstashEncoder encoder = new net.logstash.logback.encoder.LogstashEncoder();
+			LogstashEncoder encoder = new LogstashEncoder();
 
 			appender.setEncoder(encoder);
 			appender.setContext(lc);

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/failsafe/CircuitBreakerHolder.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/failsafe/CircuitBreakerHolder.java
@@ -34,16 +34,26 @@ public class CircuitBreakerHolder {
 
     private Throwable throwable;
 
+    /**
+     * Returns the message that of the error that cause the circuit to open.
+     *
+     * First tries to get the message from the cause of the {@link Throwable},
+     * if it does not exist tries to get the message from the {@link Throwable}
+     * itself.
+     *
+     * @return message of the exception that cause the circuit to open
+     */
     public String getMessage() {
         if (this.throwable == null)
             return "No Exception captured";
 
-        if (this.throwable.getCause() == null)
-            return  "No Exception cause captured";
+        if (this.throwable.getCause() != null && this.throwable.getCause().getMessage() != null)
+            return this.throwable.getCause().getMessage();
 
-        return (this.throwable.getCause().getMessage() != null) ?
-                this.throwable.getCause().getMessage() :
-                "No message available";
+        if (this.throwable.getMessage() != null)
+            return this.throwable.getMessage();
+
+        return "No error message found";
 
     }
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CacheWriterFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CacheWriterFilter.java
@@ -92,9 +92,8 @@ public class CacheWriterFilter extends ZuulFilter {
 
             long duration = (endTime - startTime);
 
-            detail.setName(this.getClass().getSimpleName());
             detail.setTimeInMillisRun(duration);
-            TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+            TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
         }
 
         return null;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CorsPostFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CorsPostFilter.java
@@ -87,8 +87,7 @@ public class CorsPostFilter extends ZuulFilter {
             long duration = (endTime - startTime);
 
             detail.setTimeInMillisRun(duration);
-            detail.setName(this.getClass().getSimpleName());
-            TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+            TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
         }
 
         return null;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CustomHostRoutingFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CustomHostRoutingFilter.java
@@ -113,9 +113,8 @@ public class CustomHostRoutingFilter extends SimpleHostRoutingFilter {
 
 			long duration = (endTime - startTime);
 
-			detail.setName(this.getClass().getSimpleName());
 			detail.setTimeInMillisRun(duration);
-			TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+			TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
 		}
 	}
 

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CustomSendResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/CustomSendResponseFilter.java
@@ -74,9 +74,8 @@ public class CustomSendResponseFilter extends SendResponseFilter {
 
 			long duration = (endTime - startTime);
 
-			detail.setName(this.getClass().getSimpleName());
 			detail.setTimeInMillisRun(duration);
-			TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+			TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
 		}
 	}
 }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallDecorationFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallDecorationFilter.java
@@ -151,9 +151,8 @@ public class HeimdallDecorationFilter extends PreDecorationFilter {
 
             long duration = (endTime - startTime);
 
-            detail.setName(this.getClass().getSimpleName());
             detail.setTimeInMillisRun(duration);
-            TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+            TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
         }
 
         return null;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/HeimdallFilter.java
@@ -92,9 +92,8 @@ public abstract class HeimdallFilter extends ZuulFilter {
 
                long duration = (endTime - startTime);
 
-               detail.setName(getName());
                detail.setTimeInMillisRun(duration);
-               TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+               TraceContextHolder.getInstance().getActualTrace().addFilter(getName(), detail);
           }
           return null;
      }     

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogRequestFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogRequestFilter.java
@@ -86,9 +86,8 @@ public class LogRequestFilter extends ZuulFilter {
 
             long duration = (endTime - startTime);
 
-            detail.setName(this.getClass().getSimpleName());
             detail.setTimeInMillisRun(duration);
-            TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+            TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
         }
         return null;
     }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/LogResponseFilter.java
@@ -82,9 +82,8 @@ public class LogResponseFilter extends ZuulFilter {
 
             long duration = (endTime - startTime);
 
-            detail.setName(this.getClass().getSimpleName());
             detail.setTimeInMillisRun(duration);
-            TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+            TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
         }
         return null;
     }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/ScopesFilter.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/ScopesFilter.java
@@ -81,9 +81,8 @@ public class ScopesFilter extends ZuulFilter {
 
             long duration = (endTime - startTime);
 
-            detail.setName(this.getClass().getSimpleName());
             detail.setTimeInMillisRun(duration);
-            TraceContextHolder.getInstance().getActualTrace().addFilter(detail);
+            TraceContextHolder.getInstance().getActualTrace().addFilter(this.getClass().getSimpleName(), detail);
         }
         return null;
     }

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/FilterDetail.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/FilterDetail.java
@@ -35,8 +35,6 @@ import lombok.Setter;
 @Data
 public class FilterDetail {
 
-     private String name;
-
      private long timeInMillisRun;
 
      private long timeInMillisShould;
@@ -61,7 +59,6 @@ public class FilterDetail {
      }
 
      public void clear() {
-          this.name = null;
           this.timeInMillisRun = 0;
           this.timeInMillisShould = 0;
           this.status = null;

--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/trace/Trace.java
@@ -44,10 +44,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import static net.logstash.logback.marker.Markers.append;
 
@@ -112,7 +109,7 @@ public class Trace {
      private List<GeneralTrace> traces = new ArrayList<>();
      
      @Getter
-     private List<FilterDetail> filters = new ArrayList<>();
+     private Map<String, FilterDetail> filters = new LinkedHashMap<>();
 
      private String profile;
      
@@ -126,7 +123,7 @@ public class Trace {
      
      @JsonIgnore
      private boolean printLogstash;
-     
+
      private String version;
      
      public Trace() {
@@ -190,8 +187,8 @@ public class Trace {
       * 
       * @param detail {@link FilterDetail}
       */
-     public void addFilter(FilterDetail detail) {
-          filters.add(detail);
+     public void addFilter(String name, FilterDetail detail) {
+          filters.put(name, detail);
      }
 
      /**
@@ -259,18 +256,19 @@ public class Trace {
      private void prepareLog(Integer statusCode) throws JsonProcessingException {
 
           String url = Objects.nonNull(getUrl()) ? getUrl() : "";
+          ObjectMapper mapper = new ObjectMapper();
 
           if (printAllTrace) {
 
                if (isInfo(statusCode)) {
 
-                    log.info(" [HEIMDALL-TRACE] - {} ", new ObjectMapper().writeValueAsString(this));
+                    log.info(" [HEIMDALL-TRACE] - {} ", mapper.writeValueAsString(this));
                } else if (isWarn(statusCode)) {
 
-                    log.warn(" [HEIMDALL-TRACE] - {} ", new ObjectMapper().writeValueAsString(this));
+                    log.warn(" [HEIMDALL-TRACE] - {} ", mapper.writeValueAsString(this));
                } else {
 
-                    log.error(" [HEIMDALL-TRACE] - {} ", new ObjectMapper().writeValueAsString(this));
+                    log.error(" [HEIMDALL-TRACE] - {} ", mapper.writeValueAsString(this));
                }
           } else {
                if (isInfo(statusCode)) {
@@ -295,16 +293,17 @@ public class Trace {
      }
 
      private void printInLogger(Logger logger, Integer statusCode) throws JsonProcessingException {
+          ObjectMapper mapper = new ObjectMapper();
 
           if (isInfo(statusCode)) {
 
-               logger.info(new ObjectMapper().writeValueAsString(this));
+               logger.info(mapper.writeValueAsString(this));
           } else if (isWarn(statusCode)) {
 
-               logger.warn(new ObjectMapper().writeValueAsString(this));
+               logger.warn(mapper.writeValueAsString(this));
           } else {
 
-               logger.error(new ObjectMapper().writeValueAsString(this));
+               logger.error(mapper.writeValueAsString(this));
           }
      }
 

--- a/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/ScopesFilterTest.java
+++ b/heimdall-gateway/src/test/java/br/com/conductor/heimdall/gateway/filter/ScopesFilterTest.java
@@ -62,6 +62,7 @@ public class ScopesFilterTest {
 
     private final String clientId1 = "client_id_1";
     private final String clientId2 = "client_id_2";
+    private final String SCOPES_FILTER = "ScopesFilter";
 
     @BeforeClass
     public static void setUp() {
@@ -107,7 +108,7 @@ public class ScopesFilterTest {
         Mockito.when(appRepository.findByClientId(Mockito.anyString())).thenReturn(app);
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -142,7 +143,7 @@ public class ScopesFilterTest {
         Mockito.when(appRepository.findByClientId(Mockito.anyString())).thenReturn(app);
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -197,7 +198,7 @@ public class ScopesFilterTest {
 
         this.filter.run();
 
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -248,7 +249,7 @@ public class ScopesFilterTest {
 
         this.filter.run();
 
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.FORBIDDEN.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -308,7 +309,7 @@ public class ScopesFilterTest {
 
         this.filter.run();
 
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -363,7 +364,7 @@ public class ScopesFilterTest {
 
         this.filter.run();
 
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.FORBIDDEN.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -394,7 +395,7 @@ public class ScopesFilterTest {
         context.set(API_ID, api.getId());
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -420,7 +421,7 @@ public class ScopesFilterTest {
         Mockito.when(appRepository.findByClientId(Mockito.anyString())).thenReturn(null);
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -445,7 +446,7 @@ public class ScopesFilterTest {
         Mockito.when(appRepository.findByClientId(Mockito.anyString())).thenReturn(app);
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -470,7 +471,7 @@ public class ScopesFilterTest {
         Mockito.when(appRepository.findByClientId(Mockito.anyString())).thenReturn(app);
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());
@@ -502,7 +503,7 @@ public class ScopesFilterTest {
         Mockito.when(appRepository.findByClientId(Mockito.anyString())).thenReturn(app);
 
         this.filter.run();
-        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(0);
+        final FilterDetail filterDetail = TraceContextHolder.getInstance().getActualTrace().getFilters().get(SCOPES_FILTER);
 
         assertEquals(HttpStatus.OK.value(), context.getResponseStatusCode());
         assertEquals(Constants.SUCCESS, filterDetail.getStatus());


### PR DESCRIPTION
Changed the way that the filters are saved in the trace

The filters were saved with a property name inside them. This has been factored out. This provides more flexibility for logging indexing.

Old trace:
```json
}
  "name": "HeimdallDecorationFilter",
  "timeInMillisRun": 107,
  "timeInMillisShould": 0,
  "status": "SUCCESS",
  "totalTimeInMillis": 107
}
```

New Trace:
```json
"HeimdallDecorationFilter": {
  "timeInMillisRun": 107,
  "timeInMillisShould": 0,
  "status": "SUCCESS",
  "totalTimeInMillis": 107
}
```
