### PR TITLE
Fixed a bug when the environments query returns an empty list

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/router/EnvironmentInfoRepository.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/router/EnvironmentInfoRepository.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Repository
@@ -48,12 +49,18 @@ public class EnvironmentInfoRepository {
         sql.append(inboundURL);
         sql.append("%'");
 
-        EnvironmentInfo environment = jdbcTemplate.query(sql.toString(), (resultSet, ignored) -> {
+        final List<EnvironmentInfo> environmentInfos = jdbcTemplate.query(sql.toString(), (resultSet, ignored) -> {
             EnvironmentInfo env = new EnvironmentInfo();
             env.setId(resultSet.getLong("id"));
             env.setOutboundURL(resultSet.getString("outboundURL"));
             return env;
-        }).get(0);
+        });
+
+        EnvironmentInfo environment = null;
+
+        if (!environmentInfos.isEmpty()) {
+            environment = environmentInfos.get(0);
+        }
 
         if (environment != null) {
 


### PR DESCRIPTION
The environments list query could return an empty list. That would cause an exception to be thrown.

This PR adds a check before retrieving the environment.