### PR TITLE
Fixed header.get() method

### DIFF
--- a/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
+++ b/heimdall-gateway/src/main/java/br/com/conductor/heimdall/gateway/filter/helper/CallImpl.java
@@ -102,7 +102,7 @@ public class CallImpl implements Call {
                     HttpServletRequest r = context.getRequest();
                     
                     String value = r.getHeader(name);
-                    if (value != null) {
+                    if (value == null) {
                          
                          value = context.getZuulRequestHeaders().get(name);
                     }


### PR DESCRIPTION
It should only try to get the header from ZuulRequestHeaders if it fails to get from HttpServletRequest.