### PR TITLE
Fixed bug when trying to delete a plan associated to an App

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/Plan.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/entity/Plan.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import javax.persistence.*;
 
+import lombok.ToString;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -67,6 +68,7 @@ public class Plan implements Serializable {
      @ManyToOne
      @JoinColumn(name = "API_ID", nullable = false)
      @JsonIgnoreProperties({ "environments" })
+     @ToString.Exclude
      private Api api;
      
      @Column(name = "CREATION_DATE", nullable = false, updatable=false)

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/exception/ExceptionMessage.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/exception/ExceptionMessage.java
@@ -112,6 +112,8 @@ public enum ExceptionMessage {
 
     ENVIRONMENT_ATTACHED_TO_API(BAD_REQUEST.value(), "Environment attached to Api", BadRequestException.class),
 
+    PLAN_ATTACHED_TO_APPS(BAD_REQUEST.value(), "Plan attached to App", BadRequestException.class),
+
     ENVIRONMENT_INBOUND_DNS_PATTERN(BAD_REQUEST.value(), "Environment inbound URL has to follow the pattern http[s]://host.domain[:port] or www.host.domain[:port]", BadRequestException.class),
     
     PROVIDER_NOT_FOUND(BAD_REQUEST.value(), "Provider not found", BadRequestException.class),

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/PlanRepository.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/repository/PlanRepository.java
@@ -24,6 +24,8 @@ package br.com.conductor.heimdall.core.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import br.com.conductor.heimdall.core.entity.Plan;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Plan Repository.
@@ -32,5 +34,14 @@ import br.com.conductor.heimdall.core.entity.Plan;
  *
  */
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+     /**
+      * Check if a plan has apps attached
+      *
+      * @param id
+      * @return
+      */
+     @Query(value = "select count(0) from apps_plans where plan_id = :id", nativeQuery = true)
+     Integer findAppsWithPlan(@Param("id") Long id);
 
 }

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/PlanService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/PlanService.java
@@ -23,6 +23,7 @@ package br.com.conductor.heimdall.core.service;
 
 import static br.com.conductor.heimdall.core.exception.ExceptionMessage.DEFAULT_PLAN_ALREADY_EXIST_TO_THIS_API;
 import static br.com.conductor.heimdall.core.exception.ExceptionMessage.GLOBAL_RESOURCE_NOT_FOUND;
+import static br.com.conductor.heimdall.core.exception.ExceptionMessage.PLAN_ATTACHED_TO_APPS;
 
 import java.util.List;
 
@@ -173,6 +174,9 @@ public class PlanService {
           Plan plan = planRepository.findOne(id);
           HeimdallException.checkThrow(plan == null, GLOBAL_RESOURCE_NOT_FOUND);
           
+          Integer totalAppsAttached = planRepository.findAppsWithPlan(id);
+          HeimdallException.checkThrow(totalAppsAttached > 0, PLAN_ATTACHED_TO_APPS);
+
           planRepository.delete(plan);
 
           amqpCacheService.dispatchClean();

--- a/heimdall-frontend/src/actions/plans/index.js
+++ b/heimdall-frontend/src/actions/plans/index.js
@@ -78,5 +78,12 @@ export const remove = planId => dispatch => {
             dispatch(getAllPlans())
             dispatch(sendNotification({ type: 'success', message: i18n.t('plan_removed') }))
         })
+        .catch(error => {
+            if (error.response && error.response.status === 400) {
+                dispatch(sendNotification({ type: 'error', message: i18n.t('error'), description: error.response.data.message }))
+            }
+            dispatch(getAllPlans())
+            dispatch(finishLoading())
+        })
 }
 


### PR DESCRIPTION
The actual scenario does not show a message to the user that it's not possible to remove a Plan attached to an App and also holds an infinite loading icon.

This pull request do:
- Show a popup error message to the user.
- Remove the infinite loading icon.
- Prevent the constraint error from API side.