### PR TITLE
Stringify Content in some interceptors

### DIFF
--- a/heimdall-api/pom.xml
+++ b/heimdall-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-api</artifactId>
 	<name>heimdall-api</name>

--- a/heimdall-core/pom.xml
+++ b/heimdall-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-core</artifactId>

--- a/heimdall-frontend/src/utils/InterceptorContentUtils.js
+++ b/heimdall-frontend/src/utils/InterceptorContentUtils.js
@@ -57,7 +57,15 @@ const logMaskerContent = content => {
     return content
 }
 
-const defaultContent = content => {
+const stringifyContent = content => {
+    if (content) {
+        return JSON.stringify(content)
+    }
+
+    return content
+}
+
+const simpleContent = content => {
     return content
 }
 
@@ -66,5 +74,6 @@ export const InterceptorContent = {
     cacheContent,
     ipsContent,
     logMaskerContent,
-    defaultContent
+    stringifyContent,
+    simpleContent
 }

--- a/heimdall-frontend/src/utils/InterceptorUtils.js
+++ b/heimdall-frontend/src/utils/InterceptorUtils.js
@@ -55,8 +55,11 @@ export const CONTENTS = (content, type) => {
             return InterceptorContent.cacheContent(content)
         case 'LOG_MASKER':
             return InterceptorContent.logMaskerContent(content)
+        case 'MIDDLEWARE':
+        case 'CUSTOM':
+            return InterceptorContent.simpleContent(content)
         default:
-            return InterceptorContent.defaultContent(content)
+            return InterceptorContent.stringifyContent(content)
     }
 }
 

--- a/heimdall-gateway/pom.xml
+++ b/heimdall-gateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>heimdall-gateway</artifactId>
 	<name>heimdall-gateway</name>

--- a/heimdall-middleware-spec/pom.xml
+++ b/heimdall-middleware-spec/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>br.com.conductor.heimdall</groupId>
 		<artifactId>heimdall</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>heimdall-middleware-spec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>br.com.conductor.heimdall</groupId>
 	<artifactId>heimdall</artifactId>
-	<version>2.4.1-SNAPSHOT</version>
+	<version>2.4.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Heimdall</name>
@@ -274,12 +274,12 @@
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-core</artifactId>
-				<version>2.4.1-SNAPSHOT</version>
+				<version>2.4.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>br.com.conductor.heimdall</groupId>
 				<artifactId>heimdall-middleware-spec</artifactId>
-				<version>2.4.1-SNAPSHOT</version>
+				<version>2.4.2-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>


### PR DESCRIPTION
**Describe Hotfix**
* Its is not possible to create interceptors of type Mock, Ratting, AccessToken, ClientId, OAuth, CacheClear, and Cors, because their content needs to be stringfied before the request is sent to the API.

**The fix**
* Created another function that returns the stringfied content and renamed the `defaultContent` function to `simpleContent` that is still used by Middleware and Custom interceptors.