### PR TITLE
Fixed LogMasker ignored headers bug

### DIFF
--- a/heimdall-frontend/src/utils/InterceptorContentUtils.js
+++ b/heimdall-frontend/src/utils/InterceptorContentUtils.js
@@ -49,6 +49,8 @@ const logMaskerContent = content => {
         if (ignoredHeaders && typeof ignoredHeaders === 'string') {
             const ignoredHeadersSplit = ignoredHeaders.split(',')
             content.ignoredHeaders = ignoredHeadersSplit.map(ignoredHeader => ignoredHeader.trim())
+        } else {
+            content.ignoredHeaders = []
         }
 
         return JSON.stringify(content)


### PR DESCRIPTION
This pull request fix a bug at Log Masker when the API receives an empty string instead receive a empty list.