### PR TITLE
Fixed bug on Add Operation Modal

### DIFF
--- a/heimdall-frontend/src/components/operations/OperationForm.js
+++ b/heimdall-frontend/src/components/operations/OperationForm.js
@@ -29,10 +29,13 @@ class OperationForm extends Component {
         this.props.resetOperation()
     }
 
-    onSubmitForm() {
+    onSubmitForm(formWithoutErrors) {
         this.props.form.validateFieldsAndScroll((err, payload) => {
             if (!err) {
+                formWithoutErrors(true);
                 this.props.onSubmit(payload)
+            }else {
+                formWithoutErrors(false);
             }
         });
     }

--- a/heimdall-frontend/src/containers/Operations.js
+++ b/heimdall-frontend/src/containers/Operations.js
@@ -57,6 +57,12 @@ class Operations extends Component {
             .then(data => {
                 this.reloadOperations()
             })
+            .catch(error => {
+                if (error.response && error.response.status === 400) {
+                    notification['error']({ message: i18n.t('error'), description: error.response.data.message })
+                }
+                this.reloadOperations()
+            })
 
     }
 
@@ -81,8 +87,11 @@ class Operations extends Component {
     }
 
     handleSave = (e) => {
-        this.operationForm.onSubmitForm()
-        this.setState({ ...this.state, operationSelected: 0, operations: null, visibleModal: false });
+        this.operationForm.onSubmitForm((formWithoutErrors) => {
+           if (formWithoutErrors) {
+               this.setState({ ...this.state, operationSelected: 0, operations: null, visibleModal: false });
+           }
+        });
     }
 
     submitPayload = (payload) => {


### PR DESCRIPTION
This pull request fixes two problems on operation modal:
- No warning is shown when user tries to add an operation without fill required fields and a infinite Loading button appears.
- When a Bad Request (400) is sent to API, the returned error message is not shown on alert component.