### PR TITLE
Fix '/manager/info' 403 Forbidden error

### DIFF
--- a/api/src/main/java/br/com/conductor/heimdall/api/configuration/SecurityConfiguration.java
+++ b/api/src/main/java/br/com/conductor/heimdall/api/configuration/SecurityConfiguration.java
@@ -65,7 +65,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests().antMatchers("/error").permitAll()
                 .and()
                 .authorizeRequests().antMatchers("/v1/api/integrations/**").permitAll()
-                .antMatchers("/v1/index.html", "/v1/swagger**", "/docs", "/v1/favicon**").permitAll()
+                .antMatchers("/v1/index.html", "/v1/swagger**", "/docs", "/v1/favicon**", "/manager/info").permitAll()
                 .antMatchers(HttpMethod.POST, ConstantsPath.PATH_LOGIN).permitAll()
                 .anyRequest().authenticated()
                 .and()


### PR DESCRIPTION
This pull request is to avoid 403 forbidden error on '/manager/info' spring actuator endpoint.