### PR TITLE
Fix null pointers exceptions

### DIFF
--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
@@ -27,6 +27,7 @@ import static br.com.conductor.heimdall.core.exception.ExceptionMessage.MIDDLEWA
 import static br.com.conductor.heimdall.core.exception.ExceptionMessage.ONLY_ONE_MIDDLEWARE_PER_VERSION_AND_API;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
@@ -26,11 +26,7 @@ import static br.com.conductor.heimdall.core.exception.ExceptionMessage.MIDDLEWA
 import static br.com.conductor.heimdall.core.exception.ExceptionMessage.MIDDLEWARE_UNSUPPORTED_TYPE;
 import static br.com.conductor.heimdall.core.exception.ExceptionMessage.ONLY_ONE_MIDDLEWARE_PER_VERSION_AND_API;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
+import java.util.*;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
+++ b/heimdall-core/src/main/java/br/com/conductor/heimdall/core/service/MiddlewareService.java
@@ -291,9 +291,9 @@ public class MiddlewareService {
 
 			if (allowInactive != null && allowInactive > 0) {
 
-				List<Middleware> active = middlewareMap.get(Status.ACTIVE);
-				List<Middleware> inactive = middlewareMap.get(Status.INACTIVE);
-				List<Middleware> deprecated = middlewareMap.get(Status.DEPRECATED);
+				List<Middleware> active = middlewareMap.get(Status.ACTIVE) != null ? middlewareMap.get(Status.ACTIVE) : Collections.emptyList();
+				List<Middleware> inactive = new ArrayList<>(middlewareMap.get(Status.INACTIVE) != null ? middlewareMap.get(Status.INACTIVE) : Collections.emptyList());
+				List<Middleware> deprecated = new ArrayList<>(middlewareMap.get(Status.DEPRECATED) != null ? middlewareMap.get(Status.DEPRECATED) : Collections.emptyList());
 
                 active.forEach(m -> m.setStatus(Status.INACTIVE));
 


### PR DESCRIPTION
**Describe bug**
If middlewaremap attribute not contains some Status (Active, Inactive or Deprecated) when is called get("status"), this method return null and consequently throw NullPointerException when used.