### PR TITLE
Fix cors undefined in front-end

### DIFF
--- a/heimdall-frontend/src/components/interceptors/wrappers/Cors.js
+++ b/heimdall-frontend/src/components/interceptors/wrappers/Cors.js
@@ -22,7 +22,7 @@ class Cors extends React.Component {
         const { content } = this.props
 
         if (content) {
-            this.setState({ ...this.state, cors: content.cors })
+            this.setState({ ...this.state, cors: content })
         }
     }
 


### PR DESCRIPTION
**Describe Hotfix**

The content from props not have attribute cors, so when is called "content.cors" undefined is returned, because content is the Cors Object now.